### PR TITLE
fix: child back button dispatcher

### DIFF
--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -103,7 +103,7 @@ class DuckShellState extends State<DuckShell> {
           final backButtonDispatcher = DuckRouter.of(context)
               .backButtonDispatcher
               .createChildBackButtonDispatcher();
-          backButtonDispatcher.takePriority;
+          backButtonDispatcher.takePriority();
 
           return Router(
             routerDelegate: _routerDelegates[i],

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -409,6 +409,73 @@ void main() {
 
       expect(result, equals(1));
     });
+
+    testWidgets('Child back button dispatcher handles back button press',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: RootLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+
+      // Navigate to a child route
+      router.navigate(to: HomeLocation());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomeScreen), findsOneWidget);
+
+      // Simulate a back button press
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      // Check if we're still on the HomeScreen (we shouldn't be)
+      expect(find.byType(HomeScreen), findsNothing);
+
+      // We should have returned to the RootLocation, but we haven't
+      expect(find.byType(Page1Screen), findsOneWidget);
+    });
+
+    testWidgets('Nested back button handling works correctly', (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: RootLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+
+      // Navigate to a child route
+      router.navigate(to: HomeLocation());
+      await tester.pumpAndSettle();
+
+      // Navigate to another child route
+      router.navigate(to: Page1Location());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Page1Screen), findsOneWidget);
+
+      // Simulate a back button press
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      // Check if we've returned to the HomeScreen
+      expect(find.byType(HomeScreen), findsOneWidget);
+      expect(find.byType(Page1Screen), findsNothing);
+
+      // Simulate another back button press
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      // Check if we've returned to the RootLocation
+      expect(find.byType(Page1Screen),
+          findsOneWidget); // This should be the initial page in RootLocation
+      expect(find.byType(HomeScreen), findsNothing);
+
+      // Try to go back again (should stay at RootLocation)
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      // Should still be at RootLocation
+      expect(find.byType(Page1Screen), findsOneWidget);
+    });
   });
 
   group('Deeplinking', () {

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -428,10 +428,7 @@ void main() {
       await tester.binding.handlePopRoute();
       await tester.pumpAndSettle();
 
-      // Check if we're still on the HomeScreen (we shouldn't be)
       expect(find.byType(HomeScreen), findsNothing);
-
-      // We should have returned to the RootLocation, but we haven't
       expect(find.byType(Page1Screen), findsOneWidget);
     });
 
@@ -464,9 +461,9 @@ void main() {
       await tester.binding.handlePopRoute();
       await tester.pumpAndSettle();
 
-      // Check if we've returned to the RootLocation
-      expect(find.byType(Page1Screen),
-          findsOneWidget); // This should be the initial page in RootLocation
+      // Should now be at first page of RootLocation
+      // Which is the Page1Screen
+      expect(find.byType(Page1Screen), findsOneWidget);
       expect(find.byType(HomeScreen), findsNothing);
 
       // Try to go back again (should stay at RootLocation)


### PR DESCRIPTION
## Description

This PR fixes an issue where we were not calling the child back button dispatcher to take priority. It was hard to replicate, but the second test this PR contributed fails for the previous code after popping twice.

## Related Issues

Closes #5

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
