### PR TITLE
feat: catch case where users pushes duplicate path

### DIFF
--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -1,5 +1,6 @@
 import 'package:duck_router/src/configuration.dart';
 import 'package:duck_router/src/delegate.dart';
+import 'package:duck_router/src/exception.dart';
 import 'package:duck_router/src/interceptor.dart';
 import 'package:duck_router/src/location.dart';
 import 'package:duck_router/src/parser.dart';
@@ -113,6 +114,11 @@ class DuckRouter implements RouterConfig<LocationStack> {
   }) {
     final currentStack = routerDelegate.currentConfiguration;
     final currentRootLocation = currentStack.locations.last;
+
+    if (!(replace ?? false) &&
+        currentStack.locations.any((loc) => loc.path == to.path)) {
+      throw DuckRouterException('Cannot push duplicate route: ${to.path}');
+    }
 
     if (currentRootLocation is StatefulLocation && !root) {
       return currentRootLocation.state.navigate(to, replace: replace);

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: prefer_const_constructors, unawaited_futures
 
 import 'package:duck_router/src/configuration.dart';
+import 'package:duck_router/src/exception.dart';
 import 'package:duck_router/src/location.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -224,6 +225,28 @@ void main() {
 
       final locations = router.routerDelegate.currentConfiguration;
       expect(locations.uri.path, '/home/page1');
+    });
+
+    testWidgets('Errors when pushing a route with a duplicate path',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      await tester.pumpAndSettle();
+
+      // Second navigation to the same path
+      expect(
+        () => router.navigate(to: HomeLocation()),
+        throwsA(isA<DuckRouterException>().having(
+          (e) => e.toString(),
+          'message',
+          contains('Cannot push duplicate route: home'),
+        )),
+      );
+
+      await tester.pumpAndSettle();
     });
   });
 


### PR DESCRIPTION
## Description

When users add two locations with the same path, e.g. `home` and `home`, the router is unable to handle that. In theory we could add some sort of randomizer to the path, but my judgement in this case is that it would be better to throw an error and have the user set an unique path instead. It would be good to then throw a specific error though. This PR implements that.

## Related Issues

Fixes #6

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
