### PR TITLE
feat: replace root() with popUntil

### DIFF
--- a/flutter/packages/duck_router/lib/src/delegate.dart
+++ b/flutter/packages/duck_router/lib/src/delegate.dart
@@ -102,8 +102,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     state?.pop(result);
   }
 
-  /// Reset the router to the root
-  void root() {
+  void popUntil(Location location) {
     final currentLocation = currentConfiguration.locations.last;
 
     if (currentLocation is StatefulLocation) {
@@ -112,16 +111,16 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       if (currentLocation.state.currentRouterDelegate.currentConfiguration
               .locations.length >
           1) {
-        return currentLocation.state.reset();
-      } else {
-        return;
+        return currentLocation.state.popUntil(location);
       }
     }
 
-    currentConfiguration = LocationStack(locations: [
-      currentConfiguration.locations.firstOrNull ??
-          _configuration.initialLocation
-    ]);
-    notifyListeners();
+    NavigatorState? state;
+    if (navigatorKey.currentState?.canPop() ?? false) {
+      state = navigatorKey.currentState;
+    }
+    state?.popUntil((route) {
+      return route.settings.name == location.path;
+    });
   }
 }

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -134,17 +134,16 @@ class DuckRouter implements RouterConfig<LocationStack> {
     );
   }
 
-  /// Reset the router to the root location.
-  void root() {
-    routerDelegate.root();
-  }
-
   /// Pop the top-most route off the current screen.
   ///
   /// If the top-most route is a pop up or dialog, this method pops it instead
   /// of any route under it.
   void pop<T extends Object?>([T? result]) {
     routerDelegate.pop<T>(result);
+  }
+
+  void popUntil(Location location) {
+    routerDelegate.popUntil(location);
   }
 
   LocationStack _initialLocation(Location userSpecifiedInitialLocation) {

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -153,6 +153,17 @@ class DuckShellState extends State<DuckShell> {
     navigatorKey.currentState?.pop(result);
   }
 
+  void popUntil(Location location) {
+    final navigatorKey = _navigatorKeys[_currentIndex];
+    if (navigatorKey.currentState == null) {
+      return;
+    }
+
+    navigatorKey.currentState?.popUntil((route) {
+      return route.settings.name == location.path;
+    });
+  }
+
   /// Resets the stack
   void reset() {
     final navigatorKey = _navigatorKeys[_currentIndex];

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -54,7 +54,7 @@ void main() {
       expect(locations2.uri.path, '/home');
     });
 
-    testWidgets('Resets to root', (tester) async {
+    testWidgets('Pops until', (tester) async {
       final config = DuckRouterConfiguration(
         initialLocation: HomeLocation(),
       );
@@ -64,42 +64,65 @@ void main() {
         to: Page1Location(),
       );
       await tester.pumpAndSettle();
+      router.navigate(
+        to: Page2Location(),
+      );
+      await tester.pumpAndSettle();
       final locations = router.routerDelegate.currentConfiguration;
-      expect(locations.locations.length, 2);
+      expect(locations.locations.length, 3);
 
-      router.root();
+      router.popUntil(
+        HomeLocation(),
+      );
       final locations2 = router.routerDelegate.currentConfiguration;
+      expect(locations2.locations.length, 1);
       expect(locations2.uri.path, '/home');
     });
 
-    testWidgets('Does not reset when already in root', (tester) async {
+    testWidgets('can popUntil just one pop', (tester) async {
       final config = DuckRouterConfiguration(
         initialLocation: HomeLocation(),
       );
 
       final router = await createRouter(config, tester);
       router.navigate(
-        to: RootLocation(),
-        replace: true,
+        to: Page1Location(),
+      );
+      await tester.pumpAndSettle();
+      router.navigate(
+        to: Page2Location(),
       );
       await tester.pumpAndSettle();
       final locations = router.routerDelegate.currentConfiguration;
-      expect(locations.uri.path, '/root');
-      router.navigate(
-        to: HomeLocation(),
-        replace: true,
+      expect(locations.locations.length, 3);
+
+      router.popUntil(
+        Page1Location(),
       );
+      final locations2 = router.routerDelegate.currentConfiguration;
+      expect(locations2.locations.length, 2);
+      expect(locations2.uri.path, '/home/page1');
+    });
+
+    testWidgets('Does nothing for popUntil if already in the location',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
       await tester.pumpAndSettle();
 
-      router.root();
-      await tester.pumpAndSettle();
-      final locations3 = router.routerDelegate.currentConfiguration;
-      expect(locations3.uri.path, '/root');
+      final locations = router.routerDelegate.currentConfiguration;
+      expect(locations.locations.length, 1);
+      expect(locations.uri.path, '/home');
 
-      router.root();
+      router.popUntil(HomeLocation());
       await tester.pumpAndSettle();
-      final locations4 = router.routerDelegate.currentConfiguration;
-      expect(locations4.uri.path, '/root');
+
+      final locations2 = router.routerDelegate.currentConfiguration;
+      expect(locations2.locations.length, 1);
+      expect(locations2.uri.path, '/home');
     });
 
     testWidgets('can await navigate', (tester) async {
@@ -318,7 +341,7 @@ void main() {
       expect(router.pop, throwsException);
     });
 
-    testWidgets('can reset', (tester) async {
+    testWidgets('Can popUntil in nested locations', (tester) async {
       final config = DuckRouterConfiguration(
         initialLocation: RootLocation(),
       );
@@ -329,24 +352,19 @@ void main() {
 
       router.navigate(to: HomeLocation());
       await tester.pumpAndSettle();
-
-      final locations2 = router.routerDelegate.currentConfiguration;
-      final statefulLocation = locations2.locations.last as StatefulLocation;
-      final child =
-          statefulLocation.state.currentRouterDelegate.currentConfiguration;
-      expect(child.uri.path, '/child1/home');
       expect(find.byType(HomeScreen), findsOneWidget);
 
-      router.root();
+      router.navigate(to: Page1Location());
       await tester.pumpAndSettle();
-      expect(
-          statefulLocation
-              .state.currentRouterDelegate.currentConfiguration.uri.path,
-          '/child1');
+      expect(find.byType(Page1Screen), findsOneWidget);
 
-      // Now we should start seeing an error because we're trying to pop
-      // the root.
-      expect(router.pop, throwsException);
+      router.navigate(to: Page2Location());
+      await tester.pumpAndSettle();
+      expect(find.byType(Page2Screen), findsOneWidget);
+
+      router.popUntil(HomeLocation());
+      await tester.pumpAndSettle();
+      expect(find.byType(HomeScreen), findsOneWidget);
     });
 
     testWidgets('can replace location', (tester) async {


### PR DESCRIPTION
## Description

The project at https://github.com/DelcoigneYves/duckrouter-example shows issues with our current API. We can not use a StatefulLocation to host a modal sheet in when we want to show a page in the background, but at that point using `root()` will bring one back all the way outside the modal sheet.

This use case of wanting to stay in the modal in that case is a standard mobile flow, and thus we need to support it. This PR:

- Removes our `root` method. This is thus a breaking change. 
- We replace `root` with `popUntil()`. `popUntil` accepts a location, and will then pop till it encounters that location. This is a simpler API than the default Flutter popUntil: https://api.flutter.dev/flutter/widgets/Navigator/popUntil.html. This is intentional, I want to keep the API simple here.

## Related Issues

- #11
- Closes #7

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
