### PR TITLE
feat!: remove StatefulChildLocation

### DIFF
--- a/flutter/packages/duck_router/README.md
+++ b/flutter/packages/duck_router/README.md
@@ -59,7 +59,7 @@ class RootLocation extends StatefulLocation {
   String get path => 'root';
 
   @override
-  List<StatefulChildLocation> get children => [
+  List<Location> get children => [
         const Child1Location(),
         const Child2Location(),
       ];
@@ -85,7 +85,7 @@ class RootLocation extends StatefulLocation {
       );
 }
 
-class Child1Location extends StatefulChildLocation {
+class Child1Location extends Location {
   const Child1Location();
 
   @override
@@ -95,7 +95,7 @@ class Child1Location extends StatefulChildLocation {
   LocationBuilder get builder => (context) => const Page1Screen();
 }
 
-class Child2Location extends StatefulChildLocation {
+class Child2Location extends Location {
   const Child2Location();
 
   @override

--- a/flutter/packages/duck_router/example/lib/main.dart
+++ b/flutter/packages/duck_router/example/lib/main.dart
@@ -36,7 +36,7 @@ class RootLocation extends StatefulLocation {
   String get path => 'root';
 
   @override
-  List<StatefulChildLocation> get children => [
+  List<Location> get children => [
         const Child1Location(),
         const Child2Location(),
       ];
@@ -46,7 +46,7 @@ class RootLocation extends StatefulLocation {
       (c, shell) => RootPage(shell: shell);
 }
 
-class Child1Location extends StatefulChildLocation {
+class Child1Location extends Location {
   const Child1Location();
 
   @override
@@ -56,7 +56,7 @@ class Child1Location extends StatefulChildLocation {
   LocationBuilder get builder => (context) => const Page1Screen();
 }
 
-class Child2Location extends StatefulChildLocation {
+class Child2Location extends Location {
   const Child2Location();
 
   @override

--- a/flutter/packages/duck_router/lib/src/location.dart
+++ b/flutter/packages/duck_router/lib/src/location.dart
@@ -111,7 +111,7 @@ abstract class StatefulLocation extends Location {
 
   /// The children of this location, these will be the root of each
   /// [Navigator] in the [DuckShell].
-  List<StatefulChildLocation> get children;
+  List<Location> get children;
 
   final GlobalKey<DuckShellState> _key = GlobalKey<DuckShellState>(
     debugLabel: 'StatefulLocationShell',
@@ -137,18 +137,6 @@ abstract class StatefulLocation extends Location {
 
   @override
   List<Object?> get props => [children, path];
-}
-
-/// {@template stateful_child_location}
-/// A location that is a child of a [StatefulLocation]. This child will have
-/// its own [LocationStack].
-/// {@endtemplate}
-abstract class StatefulChildLocation extends Location {
-  /// {@macro stateful_child_location}
-  const StatefulChildLocation();
-
-  @override
-  LocationBuilder get builder;
 }
 
 /// {@template location_list_codec}

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -24,7 +24,7 @@ class DuckShell extends StatefulWidget {
 
   /// The children of this [StatefulLocation]. Each child will have
   /// its own [DuckNavigator].
-  final List<StatefulChildLocation> children;
+  final List<Location> children;
 
   final DuckRouterConfiguration configuration;
 

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -156,7 +156,7 @@ class RootLocation extends StatefulLocation {
   String get path => 'root';
 
   @override
-  List<StatefulChildLocation> get children => [
+  List<Location> get children => [
         const Child1Location(),
         const Child2Location(),
       ];
@@ -180,7 +180,7 @@ class RootLocation extends StatefulLocation {
       );
 }
 
-class Child1Location extends StatefulChildLocation {
+class Child1Location extends Location {
   const Child1Location();
 
   @override
@@ -190,7 +190,7 @@ class Child1Location extends StatefulChildLocation {
   LocationBuilder get builder => (context) => const Page1Screen();
 }
 
-class Child2Location extends StatefulChildLocation {
+class Child2Location extends Location {
   const Child2Location();
 
   @override


### PR DESCRIPTION
## Description
As #11 rightly points out, StatefulChildLocation has no use anymore. Remove it!

## Related Issues

#11

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
