### PR TITLE
feat: revert removal of root()

### DIFF
--- a/flutter/packages/duck_router/lib/src/delegate.dart
+++ b/flutter/packages/duck_router/lib/src/delegate.dart
@@ -123,4 +123,27 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       return route.settings.name == location.path;
     });
   }
+
+  /// Reset the router to the root
+  void root() {
+    final currentLocation = currentConfiguration.locations.last;
+
+    if (currentLocation is StatefulLocation) {
+      /// Pop inside the stateful child location as long as that's possible.
+      /// Else we will pop the whole route.
+      if (currentLocation.state.currentRouterDelegate.currentConfiguration
+              .locations.length >
+          1) {
+        return currentLocation.state.reset();
+      } else {
+        return;
+      }
+    }
+
+    currentConfiguration = LocationStack(locations: [
+      currentConfiguration.locations.firstOrNull ??
+          _configuration.initialLocation
+    ]);
+    notifyListeners();
+  }
 }

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -146,6 +146,11 @@ class DuckRouter implements RouterConfig<LocationStack> {
     routerDelegate.popUntil(location);
   }
 
+  /// Reset the router to the root location.
+  void root() {
+    routerDelegate.root();
+  }
+
   LocationStack _initialLocation(Location userSpecifiedInitialLocation) {
     Uri platformInitialLocation = Uri.parse(
       WidgetsBinding.instance.platformDispatcher.defaultRouteName,


### PR DESCRIPTION
## Description

#14 made the decision to remove `root()` too quickly. This brings it back, since that function has quite a lot of value. It allows you to revert to the root of any flow, no matter what that root is. Very common on mobile. This PR reverts it.

## Related Issues

Fixes #18

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
