### PR TITLE
feat: allow popping from a nested flow

### DIFF
--- a/flutter/packages/duck_router/lib/src/delegate.dart
+++ b/flutter/packages/duck_router/lib/src/delegate.dart
@@ -111,7 +111,10 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       if (currentLocation.state.currentRouterDelegate.currentConfiguration
               .locations.length >
           1) {
-        return currentLocation.state.popUntil(location);
+        final result = currentLocation.state.popUntil(location);
+        if (result) {
+          return;
+        }
       }
     }
 

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -153,15 +153,24 @@ class DuckShellState extends State<DuckShell> {
     navigatorKey.currentState?.pop(result);
   }
 
-  void popUntil(Location location) {
+  bool popUntil(Location location) {
     final navigatorKey = _navigatorKeys[_currentIndex];
     if (navigatorKey.currentState == null) {
-      return;
+      return false;
+    }
+
+    final routerDelegate = _routerDelegates[_currentIndex];
+    final hasLocation =
+        routerDelegate.currentConfiguration.locations.contains(location);
+    if (!hasLocation) {
+      return false;
     }
 
     navigatorKey.currentState?.popUntil((route) {
       return route.settings.name == location.path;
     });
+
+    return true;
   }
 
   /// Resets the stack

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -79,6 +79,36 @@ void main() {
       expect(locations2.uri.path, '/home');
     });
 
+    testWidgets('Pops until X from nested flow', (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      router.navigate(
+        to: NestedChildRootLocation(),
+      );
+      await tester.pumpAndSettle();
+      router.navigate(
+        to: Child2Location(),
+      );
+      await tester.pumpAndSettle();
+      final locations = router.routerDelegate.currentConfiguration;
+      expect(locations.locations.length, 2);
+      final nestedLocations = (locations.locations.last as StatefulLocation)
+          .state
+          .currentRouterDelegate
+          .currentConfiguration;
+      expect(nestedLocations.locations.length, 2);
+
+      router.popUntil(
+        HomeLocation(),
+      );
+      final locations2 = router.routerDelegate.currentConfiguration;
+      expect(locations2.locations.length, 1);
+      expect(locations2.uri.path, '/home');
+    });
+
     testWidgets('can popUntil just one pop', (tester) async {
       final config = DuckRouterConfiguration(
         initialLocation: HomeLocation(),

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -181,6 +181,17 @@ class RootLocation extends StatefulLocation {
       );
 }
 
+class NestedChildRootLocation extends StatefulLocation {
+  @override
+  String get path => 'nested';
+
+  @override
+  List<Location> get children => [Child1Location()];
+
+  @override
+  StatefulLocationBuilder get childBuilder => (c, shell) => shell;
+}
+
 class Child1Location extends Location {
   const Child1Location();
 


### PR DESCRIPTION
## Description

Fixes #16 and allows to pop from a nested flow back to the root LocationStack.

## Related Issues

#16 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
