### PR TITLE
feat: expose GlobalKey in StatefulLocation

### DIFF
--- a/flutter/packages/duck_router/lib/src/location.dart
+++ b/flutter/packages/duck_router/lib/src/location.dart
@@ -114,6 +114,8 @@ abstract class StatefulLocation extends Location {
   /// [Navigator] in the [DuckShell].
   List<Location> get children;
 
+  /// The key for the [DuckShell] of this location.
+  /// This is used to access the state of the [DuckShell].
   final GlobalKey<DuckShellState> key = GlobalKey<DuckShellState>(
     debugLabel: 'StatefulLocationShell',
   );

--- a/flutter/packages/duck_router/lib/src/location.dart
+++ b/flutter/packages/duck_router/lib/src/location.dart
@@ -114,7 +114,7 @@ abstract class StatefulLocation extends Location {
   /// [Navigator] in the [DuckShell].
   List<Location> get children;
 
-  final GlobalKey<DuckShellState> _key = GlobalKey<DuckShellState>(
+  final GlobalKey<DuckShellState> key = GlobalKey<DuckShellState>(
     debugLabel: 'StatefulLocationShell',
   );
 
@@ -122,14 +122,14 @@ abstract class StatefulLocation extends Location {
   StatefulLocationBuilder get childBuilder;
 
   /// The state of the [DuckShell] for this location.
-  DuckShellState get state => _key.currentState!;
+  DuckShellState get state => key.currentState!;
 
   @override
   LocationBuilder get builder => (context) {
         return childBuilder(
           context,
           DuckShell(
-            key: _key,
+            key: key,
             children: children,
             configuration: DuckRouter.of(context).configuration,
           ),


### PR DESCRIPTION
## Description

Partial fix for #11 , so we can access the GlobalKey used in a StatefulLocation's DuckShell when wanting to override this in the pageBuilder property.

## Related Issues

#11 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
