### PR TITLE
feat: add clear stack

### DIFF
--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -107,13 +107,33 @@ class DuckRouter implements RouterConfig<LocationStack> {
   /// Use [root] to navigate from the root navigator.
   ///
   /// If [replace] is set, the current location will be replaced with [to].
+  ///
+  /// If [clearStack] is set, the current stack will be cleared before navigating.
+  /// [clearStack] will take precedence over [replace].
   Future<T?> navigate<T extends Object?>({
     required Location to,
     bool root = false,
     bool? replace,
+    bool? clearStack,
   }) {
     final currentStack = routerDelegate.currentConfiguration;
     final currentRootLocation = currentStack.locations.last;
+
+    if (clearStack ?? false) {
+      if (currentRootLocation is StatefulLocation && !root) {
+        return currentRootLocation.state.navigate(
+          to,
+          replace: replace,
+          clearStack: clearStack,
+        );
+      }
+
+      currentStack.locations.clear();
+      return routeInformationProvider.navigate<T>(
+        to,
+        baseLocationStack: currentStack,
+      );
+    }
 
     if (!(replace ?? false) &&
         currentStack.locations.any((loc) => loc.path == to.path)) {
@@ -124,7 +144,7 @@ class DuckRouter implements RouterConfig<LocationStack> {
       return currentRootLocation.state.navigate(to, replace: replace);
     }
 
-    if (replace ?? false) {
+    if ((replace ?? false)) {
       currentStack.locations.removeLast();
     }
 

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -132,8 +132,14 @@ class DuckShellState extends State<DuckShell> {
   }
 
   /// Pushes a new location to the current child's stack.
-  Future<T?> navigate<T extends Object?>(Location to, {bool? replace}) async {
-    if (replace ?? false) {
+  Future<T?> navigate<T extends Object?>(
+    Location to, {
+    bool? replace,
+    bool? clearStack,
+  }) async {
+    if (clearStack ?? false) {
+      currentRouterDelegate.currentConfiguration.locations.clear();
+    } else if (replace ?? false) {
       currentRouterDelegate.currentConfiguration.locations.removeLast();
     }
 


### PR DESCRIPTION
## Description

This PR adds an extra parameter to the navigate method, to clear the stack from all previous pages and only add the new page. Consider it a way of adding the Android's `FLAG_ACTIVITY_CLEAR_TOP` flag on an activity.
While this was also possible with `popUntil(<non-existent-page>)` and `navigate(location, replace:true)`, it was not as clean, and most importantly, a duplicate navigation animation could briefly be seen.

This is different from the `root` method, as the root method will reset to the first page in the stack, whereas this method can introduce a new page on it.

When using nested navigation, a user can choose to clear the nested stack, or the root stack with the `root` parameter.

## Related Issues

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
