### PR TITLE
feat!: use Location Type for popUntil

### DIFF
--- a/flutter/packages/duck_router/lib/src/delegate.dart
+++ b/flutter/packages/duck_router/lib/src/delegate.dart
@@ -103,12 +103,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     state?.pop(result);
   }
 
-  void popUntil<T extends Location>() {
-    if (_isSameType<T, Location>()) {
-      throw const DuckRouterException(
-          'Provided type must be a subtype of Location!');
-    }
-
+  void popUntil(LocationPredicate predicate) {
     final currentLocation = currentConfiguration.locations.last;
 
     if (currentLocation is StatefulLocation) {
@@ -117,7 +112,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       if (currentLocation.state.currentRouterDelegate.currentConfiguration
               .locations.length >
           1) {
-        final result = currentLocation.state.popUntil<T>();
+        final result = currentLocation.state.popUntil(predicate);
         if (result) {
           return;
         }
@@ -125,10 +120,10 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     }
 
     final destination = currentConfiguration.locations
-        .firstWhereOrNull((location) => location is T);
+        .firstWhereOrNull((location) => predicate(location));
     if (destination == null) {
       throw const DuckRouterException(
-          'Provided Location type cannot be found in current stack!');
+          'Provided Location predicate does not match any Locations in current stack!');
     }
 
     NavigatorState? state;
@@ -163,5 +158,3 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     notifyListeners();
   }
 }
-
-bool _isSameType<S, T>() => <S>[] is List<T> && <T>[] is List<S>;

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -162,8 +162,8 @@ class DuckRouter implements RouterConfig<LocationStack> {
     routerDelegate.pop<T>(result);
   }
 
-  void popUntil(Location location) {
-    routerDelegate.popUntil(location);
+  void popUntil<T extends Location>() {
+    routerDelegate.popUntil<T>();
   }
 
   /// Reset the router to the root location.

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -13,6 +13,9 @@ typedef DuckRouterShellBuilder = Widget Function(
   Widget child,
 );
 
+/// Signature for the [DuckRouter.popUntil] predicate argument.
+typedef LocationPredicate = bool Function(Location location);
+
 /// {@template duck_router}
 /// Creates a [DuckRouter].
 ///
@@ -162,8 +165,8 @@ class DuckRouter implements RouterConfig<LocationStack> {
     routerDelegate.pop<T>(result);
   }
 
-  void popUntil<T extends Location>() {
-    routerDelegate.popUntil<T>();
+  void popUntil(LocationPredicate predicate) {
+    routerDelegate.popUntil(predicate);
   }
 
   /// Reset the router to the root location.

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -159,14 +159,15 @@ class DuckShellState extends State<DuckShell> {
     navigatorKey.currentState?.pop(result);
   }
 
-  bool popUntil<T extends Location>() {
+  bool popUntil(LocationPredicate predicate) {
     final navigatorKey = _navigatorKeys[_currentIndex];
     if (navigatorKey.currentState == null) {
       return false;
     }
 
     final routerDelegate = _routerDelegates[_currentIndex];
-    final destination = routerDelegate.currentConfiguration.locations.firstWhereOrNull((location) => location is T);
+    final destination = routerDelegate.currentConfiguration.locations
+        .firstWhereOrNull((location) => predicate(location));
     if (destination == null) {
       return false;
     }

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -159,21 +159,20 @@ class DuckShellState extends State<DuckShell> {
     navigatorKey.currentState?.pop(result);
   }
 
-  bool popUntil(Location location) {
+  bool popUntil<T extends Location>() {
     final navigatorKey = _navigatorKeys[_currentIndex];
     if (navigatorKey.currentState == null) {
       return false;
     }
 
     final routerDelegate = _routerDelegates[_currentIndex];
-    final hasLocation =
-        routerDelegate.currentConfiguration.locations.contains(location);
-    if (!hasLocation) {
+    final destination = routerDelegate.currentConfiguration.locations.firstWhereOrNull((location) => location is T);
+    if (destination == null) {
       return false;
     }
 
     navigatorKey.currentState?.popUntil((route) {
-      return route.settings.name == location.path;
+      return route.settings.name == destination.path;
     });
 
     return true;

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -71,9 +71,7 @@ void main() {
       final locations = router.routerDelegate.currentConfiguration;
       expect(locations.locations.length, 3);
 
-      router.popUntil(
-        HomeLocation(),
-      );
+      router.popUntil<HomeLocation>();
       final locations2 = router.routerDelegate.currentConfiguration;
       expect(locations2.locations.length, 1);
       expect(locations2.uri.path, '/home');
@@ -101,9 +99,7 @@ void main() {
           .currentConfiguration;
       expect(nestedLocations.locations.length, 2);
 
-      router.popUntil(
-        HomeLocation(),
-      );
+      router.popUntil<HomeLocation>();
       final locations2 = router.routerDelegate.currentConfiguration;
       expect(locations2.locations.length, 1);
       expect(locations2.uri.path, '/home');
@@ -126,9 +122,7 @@ void main() {
       final locations = router.routerDelegate.currentConfiguration;
       expect(locations.locations.length, 3);
 
-      router.popUntil(
-        Page1Location(),
-      );
+      router.popUntil<Page1Location>();
       final locations2 = router.routerDelegate.currentConfiguration;
       expect(locations2.locations.length, 2);
       expect(locations2.uri.path, '/home/page1');
@@ -147,7 +141,7 @@ void main() {
       expect(locations.locations.length, 1);
       expect(locations.uri.path, '/home');
 
-      router.popUntil(HomeLocation());
+      router.popUntil<HomeLocation>();
       await tester.pumpAndSettle();
 
       final locations2 = router.routerDelegate.currentConfiguration;
@@ -542,7 +536,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(Page2Screen), findsOneWidget);
 
-      router.popUntil(HomeLocation());
+      router.popUntil<HomeLocation>();
       await tester.pumpAndSettle();
       expect(find.byType(HomeScreen), findsOneWidget);
     });

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -71,7 +71,7 @@ void main() {
       final locations = router.routerDelegate.currentConfiguration;
       expect(locations.locations.length, 3);
 
-      router.popUntil<HomeLocation>();
+      router.popUntil((location) => location is HomeLocation);
       final locations2 = router.routerDelegate.currentConfiguration;
       expect(locations2.locations.length, 1);
       expect(locations2.uri.path, '/home');
@@ -99,7 +99,7 @@ void main() {
           .currentConfiguration;
       expect(nestedLocations.locations.length, 2);
 
-      router.popUntil<HomeLocation>();
+      router.popUntil((location) => location is HomeLocation);
       final locations2 = router.routerDelegate.currentConfiguration;
       expect(locations2.locations.length, 1);
       expect(locations2.uri.path, '/home');
@@ -122,7 +122,7 @@ void main() {
       final locations = router.routerDelegate.currentConfiguration;
       expect(locations.locations.length, 3);
 
-      router.popUntil<Page1Location>();
+      router.popUntil((location) => location is Page1Location);
       final locations2 = router.routerDelegate.currentConfiguration;
       expect(locations2.locations.length, 2);
       expect(locations2.uri.path, '/home/page1');
@@ -141,7 +141,7 @@ void main() {
       expect(locations.locations.length, 1);
       expect(locations.uri.path, '/home');
 
-      router.popUntil<HomeLocation>();
+      router.popUntil((location) => location is HomeLocation);
       await tester.pumpAndSettle();
 
       final locations2 = router.routerDelegate.currentConfiguration;
@@ -536,7 +536,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(Page2Screen), findsOneWidget);
 
-      router.popUntil<HomeLocation>();
+      router.popUntil((location) => location is HomeLocation);
       await tester.pumpAndSettle();
       expect(find.byType(HomeScreen), findsOneWidget);
     });


### PR DESCRIPTION
## Description

As mentioned in #24, it was a bit of a weird interface to have to instantiate a new location to use in the popUntil method (especially if this Location needed parameters). So instead, popUntil is now a generic method, where the passed type is the type of the location to pop to.

I was scratching my head a bit for checking whether the passed type was actually a subtype of Location: when forgetting to add the type, the runtime type was just Location, and so it would pop to the first Location it found. Let me know if you can think of a better solution.

## Related Issues

#24 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
