### PR TITLE
migrate from onPopPage to onDidRemovePage

### DIFF
--- a/flutter/packages/duck_router/lib/src/configuration.dart
+++ b/flutter/packages/duck_router/lib/src/configuration.dart
@@ -65,8 +65,7 @@ class DuckRouterConfiguration {
   }
 
   /// Removes a location from the current dynamic directory of locations.
-  void removeLocation<T>(Location location, [FutureOr<T>? value]) {
-    _routeMapping[location.path]?.completer?.complete(value);
+  void removeLocation<T>(Location location) {
     _routeMapping.remove(location.path);
   }
 }

--- a/flutter/packages/duck_router/lib/src/delegate.dart
+++ b/flutter/packages/duck_router/lib/src/delegate.dart
@@ -1,10 +1,10 @@
 import 'package:collection/collection.dart';
-import 'package:duck_router/src/duck_router.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:duck_router/src/configuration.dart';
+import 'package:duck_router/src/duck_router.dart';
 import 'package:duck_router/src/exception.dart';
 import 'package:duck_router/src/location.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import 'navigator.dart';
 
@@ -32,18 +32,16 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       DuckNavigator(
         navigatorKey: navigatorKey,
         stack: currentConfiguration,
-        onPopPage: onPopPage,
+        onDidRemovePage: onDidRemovePage,
       ),
     );
   }
 
-  /// See RouterDelegate.onPopPage.
-  bool onPopPage(Route<Object?> route, Object? result) {
+  /// See RouterDelegate.onDidRemovePage.
+  void onDidRemovePage(Page<Object?> page) {
     final currentLocation = currentConfiguration.locations.last;
-    _configuration.removeLocation(currentLocation, result);
-
+    _configuration.removeLocation(currentLocation);
     currentConfiguration.locations.removeLast();
-    return route.didPop(result);
   }
 
   @override

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -174,6 +174,11 @@ class DuckRouter implements RouterConfig<LocationStack> {
     routerDelegate.root();
   }
 
+  void onPopInvoked(Location location, bool didPop, Object? result) {
+    final locationMatch = configuration.findLocation(location.path);
+    locationMatch?.completer?.complete(result);
+  }
+
   LocationStack _initialLocation(Location userSpecifiedInitialLocation) {
     Uri platformInitialLocation = Uri.parse(
       WidgetsBinding.instance.platformDispatcher.defaultRouteName,

--- a/flutter/packages/duck_router/lib/src/navigator.dart
+++ b/flutter/packages/duck_router/lib/src/navigator.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:duck_router/src/location.dart';
+
+import '../duck_router.dart';
 import 'pages/cupertino.dart';
 import 'pages/material.dart';
+
+typedef OnPopInvokedCallback = void Function(bool didPop, Object? result);
 
 /// {@template duck_navigator}
 /// A [Navigator] for a [LocationStack].
@@ -11,7 +14,7 @@ class DuckNavigator extends StatefulWidget {
   const DuckNavigator({
     required this.stack,
     required this.navigatorKey,
-    required this.onPopPage,
+    required this.onDidRemovePage,
     super.key,
   });
 
@@ -21,7 +24,7 @@ class DuckNavigator extends StatefulWidget {
   /// The navigator key for this navigator.
   final GlobalKey<NavigatorState> navigatorKey;
 
-  final PopPageCallback onPopPage;
+  final DidRemovePageCallback onDidRemovePage;
 
   @override
   State<StatefulWidget> createState() {
@@ -35,6 +38,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
     required LocalKey key,
     required String? name,
     required Widget child,
+    required OnPopInvokedCallback onPopInvoked,
   })? _pageBuilderForAppType;
 
   /// Rebuilds are common, so we want to cache pages to rebuild only
@@ -76,7 +80,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       child: Navigator(
         key: widget.navigatorKey,
         pages: _pages!,
-        onPopPage: widget.onPopPage,
+        onDidRemovePage: widget.onDidRemovePage,
       ),
     );
   }
@@ -115,6 +119,8 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       key: ValueKey(location.path),
       name: location.path,
       child: location.builder!(context),
+      onPopInvoked: (didPop, result) =>
+          DuckRouter.of(context).onPopInvoked(location, didPop, result),
     );
   }
 

--- a/flutter/packages/duck_router/lib/src/pages/cupertino.dart
+++ b/flutter/packages/duck_router/lib/src/pages/cupertino.dart
@@ -4,6 +4,8 @@
 
 import 'package:flutter/cupertino.dart';
 
+import '../navigator.dart';
+
 bool isCupertinoApp(BuildContext context) =>
     context.findAncestorWidgetOfExactType<CupertinoApp>() != null;
 
@@ -14,9 +16,11 @@ CupertinoPage<void> pageBuilderForCupertinoApp({
   required LocalKey key,
   required String? name,
   required Widget child,
+  required OnPopInvokedCallback onPopInvoked,
 }) =>
     CupertinoPage<void>(
       name: name,
       key: key,
       child: child,
+      onPopInvoked: onPopInvoked,
     );

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../navigator.dart';
+
 typedef TransitionBuilder = Widget Function(
   BuildContext context,
   Animation<double> animation,
@@ -29,6 +31,7 @@ class DuckPage<T> extends Page<T> {
   const DuckPage({
     required this.child,
     required this.transitionsBuilder,
+    required OnPopInvokedCallback onPopInvoked,
     this.isModal = false,
     this.transitionDuration = const Duration(milliseconds: 300),
     this.reverseTransitionDuration = const Duration(milliseconds: 300),

--- a/flutter/packages/duck_router/lib/src/pages/material.dart
+++ b/flutter/packages/duck_router/lib/src/pages/material.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 import 'package:flutter/material.dart';
 
+import '../navigator.dart';
+
 bool isMaterialApp(BuildContext context) =>
     context.findAncestorWidgetOfExactType<MaterialApp>() != null;
 
@@ -13,9 +15,11 @@ MaterialPage<void> pageBuilderForMaterialApp({
   required LocalKey key,
   required String? name,
   required Widget child,
+  required OnPopInvokedCallback onPopInvoked,
 }) =>
     MaterialPage<void>(
       name: name,
       key: key,
       child: child,
+      onPopInvoked: onPopInvoked,
     );

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -7,6 +7,7 @@ import 'package:duck_router/src/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+
 import 'navigator.dart';
 
 /// {@template duck_shell}
@@ -217,15 +218,14 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
     return DuckNavigator(
       navigatorKey: navigatorKey,
       stack: currentConfiguration,
-      onPopPage: onPopPage,
+      onDidRemovePage: onDidRemovePage,
     );
   }
 
-  bool onPopPage(Route<Object?> route, Object? result) {
+  void onDidRemovePage(Page<Object?> page) {
     final currentLocation = currentConfiguration.locations.last;
-    _routerConfiguration.removeLocation(currentLocation, result);
+    _routerConfiguration.removeLocation(currentLocation);
     currentConfiguration.locations.removeLast();
-    return route.didPop(result);
   }
 
   @override

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -261,6 +261,8 @@ class CustomPageTransitionLocation extends Location {
         child: HomeScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) =>
             FadeTransition(opacity: animation, child: child),
+        onPopInvoked: (didPop, result) =>
+            DuckRouter.of(context).onPopInvoked(this, didPop, result),
       );
 }
 


### PR DESCRIPTION
## Description

A first, dirty fix for #26 . I'm not happy with it, but it works. I would use this as a discussion starter on how to fix it.

Users need to be on Flutter version 3.24.0 to get this to work.

## Related Issues

#26 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
