### PR TITLE
feat!: migrate to onDidRemovePage

### DIFF
--- a/flutter/packages/duck_router/lib/src/delegate.dart
+++ b/flutter/packages/duck_router/lib/src/delegate.dart
@@ -32,18 +32,31 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       DuckNavigator(
         navigatorKey: navigatorKey,
         stack: currentConfiguration,
-        onPopPage: onPopPage,
+        onPopPage: _onPopPage,
+        onDidRemovePage: _onDidRemovePage,
       ),
     );
   }
 
+  /// See RouterDelegate.onDidRemovePage.
+  void _onDidRemovePage(Page<Object?> page) {
+    /// There's two cases where this function is used:
+    /// 1. When a page is popped from the stack
+    /// 2. When a page is replaced
+    ///
+    /// In scenario 2, `setNewRoutePath` is called with the new configuration
+    /// before this function, so the page will already have been removed.
+    final doesStackContainPage =
+        currentConfiguration.locations.any((l) => l.path == page.name);
+    if (doesStackContainPage) {
+      currentConfiguration.locations.removeWhere((l) => l.path == page.name);
+    }
+  }
+
   /// See RouterDelegate.onPopPage.
-  bool onPopPage(Route<Object?> route, Object? result) {
+  void _onPopPage(bool didPop, Object? result) {
     final currentLocation = currentConfiguration.locations.last;
     _configuration.removeLocation(currentLocation, result);
-
-    currentConfiguration.locations.removeLast();
-    return route.didPop(result);
   }
 
   @override

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -222,3 +222,6 @@ class InheritedDuckRouter extends InheritedWidget {
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
 }
+
+/// Callback signature for when a pop is invoked.
+typedef OnPopInvokedCallback = void Function(bool didPop, Object? result);

--- a/flutter/packages/duck_router/lib/src/location.dart
+++ b/flutter/packages/duck_router/lib/src/location.dart
@@ -63,9 +63,23 @@ typedef LocationBuilder = Widget Function(BuildContext context);
 /// For example, you might use this to build a custom transition for a page,
 /// or to use it from within a modal.
 ///
+/// To enable popping: custom pages MUST implement the [OnPopInvokedCallback]
+/// as well as set a [name] (we use the [path]) to allow the [DuckRouter] to
+/// pop the page.
+///
+/// For example:
+/// ```dart
+///   @override
+///   LocationPageBuilder get pageBuilder => (c, onPopInvoked) => CustomPage(
+///     onPopInvoked: onPopInvoked,
+///   );
+/// ```
+///
+///
 /// See also:
 /// - [LocationBuilder] for a simpler builder that returns a [Widget].
-/// - [DuckPage] for a page that allows defining a custom transition.
+/// - [DuckPage] for a page that allows defining a custom transition and handles
+/// popping for you.
 typedef LocationPageBuilder = Page<dynamic> Function(
   BuildContext context,
   OnPopInvokedCallback onPopInvoked,
@@ -73,6 +87,12 @@ typedef LocationPageBuilder = Page<dynamic> Function(
 
 /// {@template location}
 /// A location in the app.
+///
+/// See also:
+/// - [StatefulLocation] for a location that maintains its own state, such as
+/// for a bottom navigation bar.
+/// - [LocationPageBuilder] for a builder that allows you to build a custom
+/// [Page], e.g. for custom transitions.
 /// {@endtemplate}
 abstract class Location extends Equatable {
   /// {@macro location}

--- a/flutter/packages/duck_router/lib/src/location.dart
+++ b/flutter/packages/duck_router/lib/src/location.dart
@@ -68,6 +68,7 @@ typedef LocationBuilder = Widget Function(BuildContext context);
 /// - [DuckPage] for a page that allows defining a custom transition.
 typedef LocationPageBuilder = Page<dynamic> Function(
   BuildContext context,
+  OnPopInvokedCallback onPopInvoked,
 );
 
 /// {@template location}

--- a/flutter/packages/duck_router/lib/src/navigator.dart
+++ b/flutter/packages/duck_router/lib/src/navigator.dart
@@ -1,3 +1,4 @@
+import 'package:duck_router/src/exception.dart';
 import 'package:flutter/material.dart';
 import 'package:duck_router/src/location.dart';
 import 'pages/cupertino.dart';
@@ -108,7 +109,11 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       assert(l.pageBuilder != null || l.builder != null,
           'Location must have a builder or a pageBuilder');
       if (l.pageBuilder != null) {
-        pages.add(l.pageBuilder!(context));
+        final customPage = l.pageBuilder!(context);
+        if (customPage.name == null) {
+          throw DuckRouterException('Custom pages must have a name set.');
+        }
+        pages.add(customPage);
       } else {
         pages.add(_buildPage(l));
       }

--- a/flutter/packages/duck_router/lib/src/navigator.dart
+++ b/flutter/packages/duck_router/lib/src/navigator.dart
@@ -108,7 +108,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       assert(l.pageBuilder != null || l.builder != null,
           'Location must have a builder or a pageBuilder');
       if (l.pageBuilder != null) {
-        final customPage = l.pageBuilder!(context);
+        final customPage = l.pageBuilder!(context, widget.onPopPage);
         if (customPage.name == null) {
           throw DuckRouterException('Custom pages must have a name set.');
         }

--- a/flutter/packages/duck_router/lib/src/navigator.dart
+++ b/flutter/packages/duck_router/lib/src/navigator.dart
@@ -3,6 +3,8 @@ import 'package:duck_router/src/location.dart';
 import 'pages/cupertino.dart';
 import 'pages/material.dart';
 
+typedef OnPopInvokedCallback = void Function(bool didPop, Object? result);
+
 /// {@template duck_navigator}
 /// A [Navigator] for a [LocationStack].
 /// {@endtemplate}
@@ -12,6 +14,7 @@ class DuckNavigator extends StatefulWidget {
     required this.stack,
     required this.navigatorKey,
     required this.onPopPage,
+    required this.onDidRemovePage,
     super.key,
   });
 
@@ -21,7 +24,9 @@ class DuckNavigator extends StatefulWidget {
   /// The navigator key for this navigator.
   final GlobalKey<NavigatorState> navigatorKey;
 
-  final PopPageCallback onPopPage;
+  final OnPopInvokedCallback onPopPage;
+
+  final DidRemovePageCallback onDidRemovePage;
 
   @override
   State<StatefulWidget> createState() {
@@ -35,6 +40,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
     required LocalKey key,
     required String? name,
     required Widget child,
+    required OnPopInvokedCallback onPopInvoked,
   })? _pageBuilderForAppType;
 
   /// Rebuilds are common, so we want to cache pages to rebuild only
@@ -76,7 +82,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       child: Navigator(
         key: widget.navigatorKey,
         pages: _pages!,
-        onPopPage: widget.onPopPage,
+        onDidRemovePage: widget.onDidRemovePage,
       ),
     );
   }
@@ -115,6 +121,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       key: ValueKey(location.path),
       name: location.path,
       child: location.builder!(context),
+      onPopInvoked: widget.onPopPage,
     );
   }
 

--- a/flutter/packages/duck_router/lib/src/navigator.dart
+++ b/flutter/packages/duck_router/lib/src/navigator.dart
@@ -1,10 +1,9 @@
+import 'package:duck_router/src/duck_router.dart';
 import 'package:duck_router/src/exception.dart';
 import 'package:flutter/material.dart';
 import 'package:duck_router/src/location.dart';
 import 'pages/cupertino.dart';
 import 'pages/material.dart';
-
-typedef OnPopInvokedCallback = void Function(bool didPop, Object? result);
 
 /// {@template duck_navigator}
 /// A [Navigator] for a [LocationStack].

--- a/flutter/packages/duck_router/lib/src/navigator.dart
+++ b/flutter/packages/duck_router/lib/src/navigator.dart
@@ -110,7 +110,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       if (l.pageBuilder != null) {
         final customPage = l.pageBuilder!(context, widget.onPopPage);
         if (customPage.name == null) {
-          throw DuckRouterException('Custom pages must have a name set.');
+          throw const DuckRouterException('Custom pages must have a name set.');
         }
         pages.add(customPage);
       } else {

--- a/flutter/packages/duck_router/lib/src/pages/cupertino.dart
+++ b/flutter/packages/duck_router/lib/src/pages/cupertino.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:duck_router/src/navigator.dart';
+import 'package:duck_router/duck_router.dart';
 import 'package:flutter/cupertino.dart';
 
 bool isCupertinoApp(BuildContext context) =>

--- a/flutter/packages/duck_router/lib/src/pages/cupertino.dart
+++ b/flutter/packages/duck_router/lib/src/pages/cupertino.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:duck_router/src/navigator.dart';
 import 'package:flutter/cupertino.dart';
 
 bool isCupertinoApp(BuildContext context) =>
@@ -14,9 +15,11 @@ CupertinoPage<void> pageBuilderForCupertinoApp({
   required LocalKey key,
   required String? name,
   required Widget child,
+  required OnPopInvokedCallback onPopInvoked,
 }) =>
     CupertinoPage<void>(
       name: name,
       key: key,
       child: child,
+      onPopInvoked: onPopInvoked,
     );

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -27,6 +27,7 @@ typedef TransitionBuilder = Widget Function(
 class DuckPage<T> extends Page<T> {
   /// {@macro duck_page}
   const DuckPage({
+    required super.name,
     required this.child,
     required this.transitionsBuilder,
     this.isModal = false,
@@ -36,7 +37,6 @@ class DuckPage<T> extends Page<T> {
     this.canTapToDismiss = false,
     this.backgroundColor,
     this.semanticLabel,
-    super.name,
     super.arguments,
     super.restorationId,
     super.key,

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -24,10 +24,12 @@ typedef TransitionBuilder = Widget Function(
 /// )
 /// ```
 /// {@endtemplate}
+///
+/// [DuckPage] handles popping the page from the stack when the page is popped.
 class DuckPage<T> extends Page<T> {
   /// {@macro duck_page}
   const DuckPage({
-    required super.name,
+    required String name,
     required this.child,
     required this.transitionsBuilder,
     this.isModal = false,
@@ -40,7 +42,7 @@ class DuckPage<T> extends Page<T> {
     super.arguments,
     super.restorationId,
     super.key,
-  });
+  }) : super(name: name);
 
   /// Content of this page.
   final Widget child;

--- a/flutter/packages/duck_router/lib/src/pages/material.dart
+++ b/flutter/packages/duck_router/lib/src/pages/material.dart
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'package:duck_router/src/navigator.dart';
+import 'package:duck_router/duck_router.dart';
 import 'package:flutter/material.dart';
 
 bool isMaterialApp(BuildContext context) =>

--- a/flutter/packages/duck_router/lib/src/pages/material.dart
+++ b/flutter/packages/duck_router/lib/src/pages/material.dart
@@ -1,6 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'package:duck_router/src/navigator.dart';
 import 'package:flutter/material.dart';
 
 bool isMaterialApp(BuildContext context) =>
@@ -13,9 +14,11 @@ MaterialPage<void> pageBuilderForMaterialApp({
   required LocalKey key,
   required String? name,
   required Widget child,
+  required OnPopInvokedCallback onPopInvoked,
 }) =>
     MaterialPage<void>(
       name: name,
       key: key,
       child: child,
+      onPopInvoked: onPopInvoked,
     );

--- a/flutter/packages/duck_router/lib/src/shell.dart
+++ b/flutter/packages/duck_router/lib/src/shell.dart
@@ -218,14 +218,24 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
       navigatorKey: navigatorKey,
       stack: currentConfiguration,
       onPopPage: onPopPage,
+      onDidRemovePage: _onDidRemovePage,
     );
   }
 
-  bool onPopPage(Route<Object?> route, Object? result) {
+  /// See RouterDelegate.onDidRemovePage.
+  void _onDidRemovePage(Page<Object?> page) {
+    /// Please refer to DuckRouterDelegate._onDidRemovePage
+    final doesStackContainPage =
+        currentConfiguration.locations.any((l) => l.path == page.name);
+    if (doesStackContainPage) {
+      currentConfiguration.locations.removeWhere((l) => l.path == page.name);
+    }
+  }
+
+  /// See RouterDelegate.onPopPage.
+  void onPopPage(bool didPop, Object? result) {
     final currentLocation = currentConfiguration.locations.last;
     _routerConfiguration.removeLocation(currentLocation, result);
-    currentConfiguration.locations.removeLast();
-    return route.didPop(result);
   }
 
   @override

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -330,6 +330,19 @@ void main() {
         expect(locations2.locations.length, 1);
         expect(locations2.uri.path, '/home');
       });
+
+      testWidgets('Throws error when custom page has no name set',
+          (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: CustomPageLocationWithoutName(),
+        );
+
+        await createRouter(config, tester);
+        final exception = tester.takeException();
+        expect(exception, isInstanceOf<DuckRouterException>());
+        expect(exception.toString(),
+            contains('Custom pages must have a name set.'));
+      });
     });
   });
 
@@ -740,6 +753,38 @@ void main() {
       // Now we should start seeing an error because we're trying to pop
       // the root.
       expect(router.pop, throwsException);
+    });
+
+    group('Custom', () {
+      testWidgets('can host', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: RootLocationWithCustomPage(),
+        );
+
+        final router = await createRouter(config, tester);
+        final locations = router.routerDelegate.currentConfiguration;
+        expect(locations.locations.length, 1);
+        expect(locations.uri.path, '/root');
+        expect(find.byType(Scaffold), findsOneWidget);
+        expect(find.byType(CustomScreen), findsOneWidget);
+        expect(find.byType(Page2Screen), findsNothing);
+      });
+
+      testWidgets('Can pop from custom page', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: RootLocation(),
+        );
+
+        final router = await createRouter(config, tester);
+        await tester.pumpAndSettle();
+        router.navigate(to: CustomPageLocation());
+        await tester.pumpAndSettle();
+        expect(find.byType(CustomScreen), findsOneWidget);
+
+        router.pop();
+        await tester.pumpAndSettle();
+        expect(find.byType(Page1Screen), findsOneWidget);
+      });
     });
   });
 

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -286,28 +286,50 @@ void main() {
       expect(find.byType(HomeScreen), findsOneWidget);
     });
 
-    testWidgets('can specify custom page', (tester) async {
-      final config = DuckRouterConfiguration(
-        initialLocation: CustomPageLocation(),
-      );
+    group('Custom page', () {
+      testWidgets('can specify custom page', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: CustomPageLocation(),
+        );
 
-      final router = await createRouterOnIos(config, tester);
-      final locations = router.routerDelegate.currentConfiguration;
-      expect(locations.locations.length, 1);
-      expect(locations.uri.path, '/custom-page');
-      expect(find.byType(CustomScreen), findsOneWidget);
-    });
+        final router = await createRouterOnIos(config, tester);
+        final locations = router.routerDelegate.currentConfiguration;
+        expect(locations.locations.length, 1);
+        expect(locations.uri.path, '/custom-page');
+        expect(find.byType(CustomScreen), findsOneWidget);
+      });
 
-    testWidgets('can specify custom page transition', (tester) async {
-      final config = DuckRouterConfiguration(
-        initialLocation: CustomPageTransitionLocation(),
-      );
+      testWidgets('can specify custom page transition', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: CustomPageTransitionLocation(),
+        );
 
-      final router = await createRouterOnIos(config, tester);
-      final locations = router.routerDelegate.currentConfiguration;
-      expect(locations.locations.length, 1);
-      expect(locations.uri.path, '/custom-page-transition');
-      expect(find.byType(HomeScreen), findsOneWidget);
+        final router = await createRouterOnIos(config, tester);
+        final locations = router.routerDelegate.currentConfiguration;
+        expect(locations.locations.length, 1);
+        expect(locations.uri.path, '/custom-page-transition');
+        expect(find.byType(HomeScreen), findsOneWidget);
+      });
+
+      testWidgets('Can pop from custom page', (tester) async {
+        final config = DuckRouterConfiguration(
+          initialLocation: HomeLocation(),
+        );
+
+        final router = await createRouter(config, tester);
+        router.navigate(to: CustomPageLocation());
+        await tester.pumpAndSettle();
+        final locations = router.routerDelegate.currentConfiguration;
+        expect(locations.locations.length, 2);
+        expect(locations.uri.path, '/home/custom-page');
+        expect(find.byType(CustomScreen), findsOneWidget);
+
+        router.pop();
+        await tester.pumpAndSettle();
+        final locations2 = router.routerDelegate.currentConfiguration;
+        expect(locations2.locations.length, 1);
+        expect(locations2.uri.path, '/home');
+      });
     });
   });
 

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -192,6 +192,35 @@ class NestedChildRootLocation extends StatefulLocation {
   StatefulLocationBuilder get childBuilder => (c, shell) => shell;
 }
 
+class RootLocationWithCustomPage extends StatefulLocation {
+  @override
+  String get path => 'root';
+
+  @override
+  List<Location> get children => [
+        const CustomPageLocation(),
+        const Child1Location(),
+      ];
+
+  @override
+  StatefulLocationBuilder get childBuilder => (c, shell) => Scaffold(
+        body: shell,
+        bottomNavigationBar: BottomNavigationBar(
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.home),
+              label: 'Page 1',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.settings),
+              label: 'Page 2',
+            ),
+          ],
+          onTap: (value) => shell.switchChild(value),
+        ),
+      );
+}
+
 class Child1Location extends Location {
   const Child1Location();
 
@@ -266,6 +295,10 @@ class CustomPageTransitionLocation extends Location {
 }
 
 class CustomPage<T> extends Page<T> {
+  const CustomPage({
+    super.name = 'custom-page',
+  });
+
   @override
   Route<T> createRoute(BuildContext context) {
     return MaterialPageRoute<T>(
@@ -282,4 +315,24 @@ class CustomScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => const Placeholder();
+}
+
+class CustomPageLocationWithoutName extends Location {
+  const CustomPageLocationWithoutName();
+
+  @override
+  String get path => 'custom-page-without-name';
+
+  @override
+  LocationPageBuilder get pageBuilder => (context) => CustomPageWithoutName();
+}
+
+class CustomPageWithoutName<T> extends Page<T> {
+  @override
+  Route<T> createRoute(BuildContext context) {
+    return MaterialPageRoute<T>(
+      settings: this,
+      builder: (context) => const CustomScreen(),
+    );
+  }
 }

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -276,7 +276,9 @@ class CustomPageLocation extends Location {
   String get path => 'custom-page';
 
   @override
-  LocationPageBuilder get pageBuilder => (context) => CustomPage();
+  LocationPageBuilder get pageBuilder => (context, onPopInvoked) => CustomPage(
+        onPopInvoked: onPopInvoked,
+      );
 }
 
 class CustomPageTransitionLocation extends Location {
@@ -286,7 +288,7 @@ class CustomPageTransitionLocation extends Location {
   String get path => 'custom-page-transition';
 
   @override
-  LocationPageBuilder get pageBuilder => (context) => DuckPage(
+  LocationPageBuilder get pageBuilder => (context, onPopInvoked) => DuckPage(
         name: path,
         child: HomeScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) =>
@@ -297,6 +299,7 @@ class CustomPageTransitionLocation extends Location {
 class CustomPage<T> extends Page<T> {
   const CustomPage({
     super.name = 'custom-page',
+    super.onPopInvoked,
   });
 
   @override
@@ -324,10 +327,15 @@ class CustomPageLocationWithoutName extends Location {
   String get path => 'custom-page-without-name';
 
   @override
-  LocationPageBuilder get pageBuilder => (context) => CustomPageWithoutName();
+  LocationPageBuilder get pageBuilder =>
+      (context, onPopInvoked) => CustomPageWithoutName(
+            onPopInvoked: onPopInvoked,
+          );
 }
 
 class CustomPageWithoutName<T> extends Page<T> {
+  const CustomPageWithoutName({super.onPopInvoked});
+
   @override
   Route<T> createRoute(BuildContext context) {
     return MaterialPageRoute<T>(

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -258,6 +258,7 @@ class CustomPageTransitionLocation extends Location {
 
   @override
   LocationPageBuilder get pageBuilder => (context) => DuckPage(
+        name: path,
         child: HomeScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) =>
             FadeTransition(opacity: animation, child: child),


### PR DESCRIPTION
## Description

This PR migrates DuckRouter to the new Page API for popping pages, see https://docs.flutter.dev/release/breaking-changes/navigator-and-page-api. 

The change has a fundamental impact on us. The suggestion made in the breaking change doc is to remove the page from your list of pages. In our case, that would be in DuckNavigator. The problem we have is that DuckNavigator is that's not where we keep state. That's because we use Navigator both in nested and un-nested contexts. We keep state in the DuckShell and in the DuckRouterDelegate. But at that level, we have abstracted away our use of Page. So when Navigator returns us the page that's been popped, we don't really have a use for it, and we cannot find the corresponding Location for it. At that point we have three choices:

- When the callback gets triggered, just pop stack
- Try to find the location
- Change our mapping of `_pages` in `DuckNavigator`

This PR has gone for the second option, mandating the `name` field on any Page objects given to DuckRouter and using that to find the Location by path. I tried option 3 too, by implementing a mapping of Location and Page objects in `_updatePages`, but tests started failing as soon as I did that.

The stance I have taken is that, just like our previous implementation, this system should be hidden from the user of DuckRouter. This was mostly possible, with one exception: If a user uses a totally custom Page, i.e. a custom override of Page without using DuckPage, they are not required by the Page API to add a name (it's optional). Thus, in that case we are forced to throw an error.

## Related Issues

#26 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
