### PR TITLE
feat!: remove need to specify onPopInvoked

### DIFF
--- a/flutter/packages/duck_router/README.md
+++ b/flutter/packages/duck_router/README.md
@@ -131,3 +131,49 @@ final router = DuckRouter(
 ```
 
 This gives you the current location and the URI for the deeplink, and asks you to return a stack of locations, with the last entry being the page shown. In cases where it's considered likely for the route to be intercepted (e.g. by a login screen), consider keeping the deeplink location in memory and acting upon it later.
+
+## Custom pages
+
+DuckRouter uses the [Pages](https://api.flutter.dev/flutter/widgets/Page-class.html) API from Flutter to handle the conversions to [Routes](https://api.flutter.dev/flutter/widgets/Route-class.html). This means that to specify a non-default route, such as a dialog, we need to override [Page]. DuckRouter provides [DuckPage] for this purpose.
+
+Let's take the case of a dialog:
+
+```dart
+class DialogPage<T> extends DuckPage<T> {
+  const DialogPage({
+    required String name,
+    required this.builder,
+    super.key,
+    super.arguments,
+    super.restorationId,
+  }) : super.custom(name: name);
+
+  final WidgetBuilder builder;
+
+   @override
+   Route<T> createRoute(BuildContext context) => DialogRoute<T>(
+         context: context,
+         settings: this,
+         builder: (context) => Dialog(
+           child: builder(context),
+         ),
+       );
+ }
+```
+
+We can then use this page like so:
+
+```dart
+class DialogPageLocation extends Location {
+  const DialogPageLocation();
+
+  @override
+  String get path => 'dialog-page';
+
+  @override
+  LocationPageBuilder get pageBuilder=> (context) => DialogPage(
+    name: path,
+    builder: ...
+  );
+}
+```

--- a/flutter/packages/duck_router/README.md
+++ b/flutter/packages/duck_router/README.md
@@ -134,7 +134,7 @@ This gives you the current location and the URI for the deeplink, and asks you t
 
 ## Custom pages
 
-DuckRouter uses the [Pages](https://api.flutter.dev/flutter/widgets/Page-class.html) API from Flutter to handle the conversions to [Routes](https://api.flutter.dev/flutter/widgets/Route-class.html). This means that to specify a non-default route, such as a dialog, we need to override [Page]. DuckRouter provides [DuckPage] for this purpose.
+DuckRouter uses the [Pages](https://api.flutter.dev/flutter/widgets/Page-class.html) API from Flutter to handle the conversions to [Routes](https://api.flutter.dev/flutter/widgets/Route-class.html). This means that to specify a non-default route, such as a dialog, we need to override `Page`. DuckRouter provides `DuckPage` for this purpose.
 
 Let's take the case of a dialog:
 

--- a/flutter/packages/duck_router/README.md
+++ b/flutter/packages/duck_router/README.md
@@ -177,3 +177,9 @@ class DialogPageLocation extends Location {
   );
 }
 ```
+
+And to open it, all we do is:
+
+```dart
+DuckRouter.of(context).navigate(to: DialogPageLocation);
+```

--- a/flutter/packages/duck_router/README.md
+++ b/flutter/packages/duck_router/README.md
@@ -132,11 +132,32 @@ final router = DuckRouter(
 
 This gives you the current location and the URI for the deeplink, and asks you to return a stack of locations, with the last entry being the page shown. In cases where it's considered likely for the route to be intercepted (e.g. by a login screen), consider keeping the deeplink location in memory and acting upon it later.
 
-## Custom pages
+## Custom transitions and custom pages
 
-DuckRouter uses the [Pages](https://api.flutter.dev/flutter/widgets/Page-class.html) API from Flutter to handle the conversions to [Routes](https://api.flutter.dev/flutter/widgets/Route-class.html). This means that to specify a non-default route, such as a dialog, we need to override `Page`. DuckRouter provides `DuckPage` for this purpose.
+DuckRouter uses the [Pages](https://api.flutter.dev/flutter/widgets/Page-class.html) API from Flutter to handle the conversions to [Routes](https://api.flutter.dev/flutter/widgets/Route-class.html).
 
-Let's take the case of a dialog:
+To have a page animate with a custom transition, we can use `DuckPage`:
+
+```dart
+class CustomPageTransitionLocation extends Location {
+  const CustomPageTransitionLocation();
+
+  @override
+  String get path => 'custom-page-transition';
+
+  @override
+  LocationPageBuilder get pageBuilder => (context) => DuckPage(
+        name: path,
+        child: HomeScreen(),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+            FadeTransition(opacity: animation, child: child),
+      );
+}
+```
+
+In this case `DuckPage` will create a custom route for you. This means that to specify a non-default route, such as a dialog, we need to override `DuckPage`.
+
+Let's take the case of a dialog (but you can implement any type of Route in this way):
 
 ```dart
 class DialogPage<T> extends DuckPage<T> {

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -222,6 +222,3 @@ class InheritedDuckRouter extends InheritedWidget {
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
 }
-
-/// Callback signature for when a pop is invoked.
-typedef OnPopInvokedCallback = void Function(bool didPop, Object? result);

--- a/flutter/packages/duck_router/lib/src/exception.dart
+++ b/flutter/packages/duck_router/lib/src/exception.dart
@@ -1,5 +1,4 @@
 import 'package:duck_router/duck_router.dart';
-import 'package:flutter/widgets.dart' as widgets;
 
 /// {@template duck_router_exception}
 /// Exception thrown by the [DuckRouter].
@@ -13,32 +12,4 @@ class DuckRouterException implements Exception {
 
   @override
   String toString() => 'RouterException: $message';
-}
-
-class DuckRouterError extends widgets.FlutterError {
-  DuckRouterError({
-    required String summary,
-    required List<String> details,
-  }) : super.fromParts(<widgets.DiagnosticsNode>[
-          widgets.ErrorSummary(summary),
-          ...details.map((detail) => widgets.ErrorDescription(detail)),
-        ]);
-
-  factory DuckRouterError.missingOverride({
-    required widgets.Widget? child,
-    required TransitionBuilder? transitionsBuilder,
-  }) {
-    return DuckRouterError(
-      summary: 'Invalid DuckPage configuration',
-      details: [
-        'When using a custom DuckPage, you must override createRoute or provide both child and transitionsBuilder.',
-        'Current configuration:',
-        '  child: ${child ?? 'null'}',
-        '  transitionsBuilder: ${transitionsBuilder ?? 'null'}',
-        'To fix this, either:',
-        '  1. Override the createRoute method in your custom DuckPage, or',
-        '  2. Provide both child and transitionsBuilder when creating DuckPage.',
-      ],
-    );
-  }
 }

--- a/flutter/packages/duck_router/lib/src/exception.dart
+++ b/flutter/packages/duck_router/lib/src/exception.dart
@@ -1,3 +1,6 @@
+import 'package:duck_router/duck_router.dart';
+import 'package:flutter/widgets.dart' as widgets;
+
 /// {@template duck_router_exception}
 /// Exception thrown by the [DuckRouter].
 /// {@endtemplate}
@@ -10,4 +13,32 @@ class DuckRouterException implements Exception {
 
   @override
   String toString() => 'RouterException: $message';
+}
+
+class DuckRouterError extends widgets.FlutterError {
+  DuckRouterError({
+    required String summary,
+    required List<String> details,
+  }) : super.fromParts(<widgets.DiagnosticsNode>[
+          widgets.ErrorSummary(summary),
+          ...details.map((detail) => widgets.ErrorDescription(detail)),
+        ]);
+
+  factory DuckRouterError.missingOverride({
+    required widgets.Widget? child,
+    required TransitionBuilder? transitionsBuilder,
+  }) {
+    return DuckRouterError(
+      summary: 'Invalid DuckPage configuration',
+      details: [
+        'When using a custom DuckPage, you must override createRoute or provide both child and transitionsBuilder.',
+        'Current configuration:',
+        '  child: ${child ?? 'null'}',
+        '  transitionsBuilder: ${transitionsBuilder ?? 'null'}',
+        'To fix this, either:',
+        '  1. Override the createRoute method in your custom DuckPage, or',
+        '  2. Provide both child and transitionsBuilder when creating DuckPage.',
+      ],
+    );
+  }
 }

--- a/flutter/packages/duck_router/lib/src/location.dart
+++ b/flutter/packages/duck_router/lib/src/location.dart
@@ -58,31 +58,59 @@ class LocationStack {
 /// a [Page].
 typedef LocationBuilder = Widget Function(BuildContext context);
 
-/// A builder that allows a fully custom [Page] to be built.
+/// A builder that allows a fully custom [Page] to be built. We call these
+/// custom pages [DuckPage].
 ///
 /// For example, you might use this to build a custom transition for a page,
-/// or to use it from within a modal.
+/// or to use it from within a modal. Here's how you would use it to build a
+/// dialog page:
 ///
-/// To enable popping: custom pages MUST implement the [OnPopInvokedCallback]
-/// as well as set a [name] (we use the [path]) to allow the [DuckRouter] to
-/// pop the page.
-///
-/// For example:
 /// ```dart
+/// class DialogPage<T> extends DuckPage<T> {
+///   final Offset? anchorPoint;
+///   final Color? barrierColor;
+///   final bool barrierDismissible;
+///   final String? barrierLabel;
+///   final bool useSafeArea;
+///   final CapturedThemes? themes;
+///   final WidgetBuilder builder;
+///
+///   const DialogPage.custom({
+///     required String name,
+///     required this.builder,
+///     this.anchorPoint,
+///     this.barrierColor = Colors.black87,
+///     this.barrierDismissible = true,
+///     this.barrierLabel,
+///     this.useSafeArea = true,
+///     this.themes,
+///     super.key,
+///     super.arguments,
+///     super.restorationId,
+///   }) : super.custom(name: name);
+///
 ///   @override
-///   LocationPageBuilder get pageBuilder => (c, onPopInvoked) => CustomPage(
-///     onPopInvoked: onPopInvoked,
-///   );
+///   Route<T> createRoute(BuildContext context) => DialogRoute<T>(
+///         context: context,
+///         settings: this,
+///         builder: (context) => Dialog(
+///           child: builder(context),
+///         ),
+///         anchorPoint: anchorPoint,
+///         barrierColor: barrierColor,
+///         barrierDismissible: barrierDismissible,
+///         barrierLabel: barrierLabel,
+///         useSafeArea: useSafeArea,
+///         themes: themes,
+///       );
+/// }
 /// ```
 ///
-///
 /// See also:
-/// - [LocationBuilder] for a simpler builder that returns a [Widget].
-/// - [DuckPage] for a page that allows defining a custom transition and handles
-/// popping for you.
-typedef LocationPageBuilder = Page<dynamic> Function(
+/// * [LocationBuilder] for a simpler builder that returns a [Widget].
+/// * [DuckPage] for the page you must override.
+typedef LocationPageBuilder = DuckPage<dynamic> Function(
   BuildContext context,
-  OnPopInvokedCallback onPopInvoked,
 );
 
 /// {@template location}

--- a/flutter/packages/duck_router/lib/src/navigator.dart
+++ b/flutter/packages/duck_router/lib/src/navigator.dart
@@ -1,4 +1,3 @@
-import 'package:duck_router/src/duck_router.dart';
 import 'package:duck_router/src/exception.dart';
 import 'package:flutter/material.dart';
 import 'package:duck_router/src/location.dart';
@@ -108,7 +107,7 @@ class _DuckNavigatorState extends State<DuckNavigator> {
       assert(l.pageBuilder != null || l.builder != null,
           'Location must have a builder or a pageBuilder');
       if (l.pageBuilder != null) {
-        final customPage = l.pageBuilder!(context, widget.onPopPage);
+        final customPage = l.pageBuilder!(context);
         if (customPage.name == null) {
           throw const DuckRouterException('Custom pages must have a name set.');
         }
@@ -143,3 +142,6 @@ class _DuckNavigatorState extends State<DuckNavigator> {
     assert(_pageBuilderForAppType != null, 'App type not found!');
   }
 }
+
+/// Callback signature for when a pop is invoked.
+typedef OnPopInvokedCallback = void Function(bool didPop, Object? result);

--- a/flutter/packages/duck_router/lib/src/pages/cupertino.dart
+++ b/flutter/packages/duck_router/lib/src/pages/cupertino.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:duck_router/duck_router.dart';
+import 'package:duck_router/src/navigator.dart';
 import 'package:flutter/cupertino.dart';
 
 bool isCupertinoApp(BuildContext context) =>

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -9,7 +9,8 @@ typedef TransitionBuilder = Widget Function(
 );
 
 /// {@template duck_page}
-/// DuckPage is a page that allows defining a custom transition.
+/// DuckPage is a [Page] that integrates with DuckRouter, and can provide more
+/// control over the transition and behavior of a page.
 ///
 /// For example:
 ///
@@ -24,9 +25,14 @@ typedef TransitionBuilder = Widget Function(
 ///   },
 /// )
 /// ```
-/// {@endtemplate}
 ///
-/// [DuckPage] handles popping the page from the stack when the page is popped.
+/// You can use the [DuckPage.custom] constructor to build a fully custom route,
+/// such as a dialog.
+///
+/// See also:
+/// - [LocationPageBuilder]: a builder that allows returning a custom [Page]
+/// for a location.
+/// {@endtemplate}
 class DuckPage<T> extends Page<T> {
   /// {@macro duck_page}
   const DuckPage({

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -124,8 +124,9 @@ class DuckPage<T> extends Page<T> {
   @override
   Route<T> createRoute(BuildContext context) {
     if (child == null || transitionsBuilder == null) {
-      throw DuckRouterException(
-          'When using a custom DuckPage, you must override createRoute');
+      throw const DuckRouterException(
+        'When using a custom DuckPage, you must override createRoute',
+      );
     }
     return _DuckPageRoute<T>(this);
   }

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -53,6 +53,10 @@ class DuckPage<T> extends Page<T> {
         assert(transitionsBuilder != null),
         super(name: name);
 
+  /// Creates a custom [DuckPage].
+  ///
+  /// When using this constructor, you must override [createRoute] to return a
+  /// custom [Route].
   const DuckPage.custom({
     required String name,
     this.isModal = false,

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -1,3 +1,4 @@
+import 'package:duck_router/src/exception.dart';
 import 'package:flutter/material.dart';
 
 typedef TransitionBuilder = Widget Function(
@@ -42,10 +43,28 @@ class DuckPage<T> extends Page<T> {
     super.arguments,
     super.restorationId,
     super.key,
-  }) : super(name: name);
+  })  : assert(child != null),
+        assert(transitionsBuilder != null),
+        super(name: name);
+
+  const DuckPage.custom({
+    required String name,
+    this.isModal = false,
+    this.transitionDuration = const Duration(milliseconds: 300),
+    this.reverseTransitionDuration = const Duration(milliseconds: 300),
+    this.maintainState = false,
+    this.canTapToDismiss = false,
+    this.backgroundColor,
+    this.semanticLabel,
+    super.arguments,
+    super.restorationId,
+    super.key,
+  })  : child = null,
+        transitionsBuilder = null,
+        super(name: name);
 
   /// Content of this page.
-  final Widget child;
+  final Widget? child;
 
   /// Duration of the transition.
   ///
@@ -94,10 +113,16 @@ class DuckPage<T> extends Page<T> {
   ///
   /// See also:
   /// - [ModalRoute.buildTransitions] for more information on how to use this.
-  final TransitionBuilder transitionsBuilder;
+  final TransitionBuilder? transitionsBuilder;
 
   @override
-  Route<T> createRoute(BuildContext context) => _DuckPageRoute<T>(this);
+  Route<T> createRoute(BuildContext context) {
+    if (child == null || transitionsBuilder == null) {
+      throw DuckRouterException(
+          'When using a custom DuckPage, you must override createRoute');
+    }
+    return _DuckPageRoute<T>(this);
+  }
 }
 
 class _DuckPageRoute<T> extends PageRoute<T> {
@@ -145,7 +170,7 @@ class _DuckPageRoute<T> extends PageRoute<T> {
     Animation<double> secondaryAnimation,
     Widget child,
   ) =>
-      _page.transitionsBuilder(
+      _page.transitionsBuilder!(
         context,
         animation,
         secondaryAnimation,

--- a/flutter/packages/duck_router/lib/src/pages/custom.dart
+++ b/flutter/packages/duck_router/lib/src/pages/custom.dart
@@ -121,6 +121,13 @@ class DuckPage<T> extends Page<T> {
   /// - [ModalRoute.buildTransitions] for more information on how to use this.
   final TransitionBuilder? transitionsBuilder;
 
+  /// Creates a [Route] for this page.
+  ///
+  /// You should override this if you are using the [DuckPage.custom]
+  /// constructor.
+  ///
+  /// That will enable you to create a fully custom route, such as a dialog via
+  /// DialogRoute, or a CupertinoPageRoute, or any other custom route.
   @override
   Route<T> createRoute(BuildContext context) {
     if (child == null || transitionsBuilder == null) {

--- a/flutter/packages/duck_router/lib/src/pages/material.dart
+++ b/flutter/packages/duck_router/lib/src/pages/material.dart
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'package:duck_router/duck_router.dart';
+import 'package:duck_router/src/navigator.dart';
 import 'package:flutter/material.dart';
 
 bool isMaterialApp(BuildContext context) =>

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -344,7 +344,7 @@ void main() {
 
         final page = FaultyCustomPage();
         try {
-          await page.createRoute(context);
+          page.createRoute(context);
           fail('Should have thrown an error');
         } catch (e) {
           expect(e, isInstanceOf<DuckRouterException>());

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -331,17 +331,28 @@ void main() {
         expect(locations2.uri.path, '/home');
       });
 
-      testWidgets('Throws error when custom page has no name set',
+      testWidgets('Throws error when custom page does not override createRoute',
           (tester) async {
-        final config = DuckRouterConfiguration(
-          initialLocation: CustomPageLocationWithoutName(),
+        late BuildContext context;
+
+        await tester.pumpWidget(
+          Builder(builder: (c) {
+            context = c;
+            return Container();
+          }),
         );
 
-        await createRouter(config, tester);
-        final exception = tester.takeException();
-        expect(exception, isInstanceOf<DuckRouterException>());
-        expect(exception.toString(),
-            contains('Custom pages must have a name set.'));
+        final page = FaultyCustomPage();
+        try {
+          await page.createRoute(context);
+          fail('Should have thrown an error');
+        } catch (e) {
+          expect(e, isInstanceOf<DuckRouterException>());
+          expect(
+              e.toString(),
+              contains(
+                  'When using a custom DuckPage, you must override createRoute'));
+        }
       });
     });
   });

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -317,8 +317,10 @@ class CustomScreen extends StatelessWidget {
   Widget build(BuildContext context) => const Placeholder();
 }
 
+/// This is a fauly custom implementation because it uses the custom constructor
+/// without overriding `createRoute`.
 class FaultyCustomPage<T> extends DuckPage<T> {
   const FaultyCustomPage({
-    super.name = 'custom-page-without-name',
+    super.name = 'faulty-custom-page',
   }) : super.custom();
 }

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -276,9 +276,7 @@ class CustomPageLocation extends Location {
   String get path => 'custom-page';
 
   @override
-  LocationPageBuilder get pageBuilder => (context, onPopInvoked) => CustomPage(
-        onPopInvoked: onPopInvoked,
-      );
+  LocationPageBuilder get pageBuilder => (context) => CustomPage();
 }
 
 class CustomPageTransitionLocation extends Location {
@@ -288,7 +286,7 @@ class CustomPageTransitionLocation extends Location {
   String get path => 'custom-page-transition';
 
   @override
-  LocationPageBuilder get pageBuilder => (context, onPopInvoked) => DuckPage(
+  LocationPageBuilder get pageBuilder => (context) => DuckPage(
         name: path,
         child: HomeScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) =>
@@ -296,11 +294,10 @@ class CustomPageTransitionLocation extends Location {
       );
 }
 
-class CustomPage<T> extends Page<T> {
+class CustomPage<T> extends DuckPage<T> {
   const CustomPage({
-    super.name = 'custom-page',
-    super.onPopInvoked,
-  });
+    String name = 'custom-page',
+  }) : super.custom(name: name);
 
   @override
   Route<T> createRoute(BuildContext context) {
@@ -320,27 +317,8 @@ class CustomScreen extends StatelessWidget {
   Widget build(BuildContext context) => const Placeholder();
 }
 
-class CustomPageLocationWithoutName extends Location {
-  const CustomPageLocationWithoutName();
-
-  @override
-  String get path => 'custom-page-without-name';
-
-  @override
-  LocationPageBuilder get pageBuilder =>
-      (context, onPopInvoked) => CustomPageWithoutName(
-            onPopInvoked: onPopInvoked,
-          );
-}
-
-class CustomPageWithoutName<T> extends Page<T> {
-  const CustomPageWithoutName({super.onPopInvoked});
-
-  @override
-  Route<T> createRoute(BuildContext context) {
-    return MaterialPageRoute<T>(
-      settings: this,
-      builder: (context) => const CustomScreen(),
-    );
-  }
+class FaultyCustomPage<T> extends DuckPage<T> {
+  const FaultyCustomPage({
+    String name = 'custom-page-without-name',
+  }) : super.custom(name: name);
 }

--- a/flutter/packages/duck_router/test/src/test_helpers.dart
+++ b/flutter/packages/duck_router/test/src/test_helpers.dart
@@ -296,8 +296,8 @@ class CustomPageTransitionLocation extends Location {
 
 class CustomPage<T> extends DuckPage<T> {
   const CustomPage({
-    String name = 'custom-page',
-  }) : super.custom(name: name);
+    super.name = 'custom-page',
+  }) : super.custom();
 
   @override
   Route<T> createRoute(BuildContext context) {
@@ -319,6 +319,6 @@ class CustomScreen extends StatelessWidget {
 
 class FaultyCustomPage<T> extends DuckPage<T> {
   const FaultyCustomPage({
-    String name = 'custom-page-without-name',
-  }) : super.custom(name: name);
+    super.name = 'custom-page-without-name',
+  }) : super.custom();
 }


### PR DESCRIPTION
## Description

This is an iteration upon #28. There, we started supporting Flutter's `onDidRemovePage` callback. However, we had to make a compromise where users had to implement onPopInvoked when overriding Page.

This PR is an iteration on that PR. It removes the need to implement onPopInvoked, it is now handled automatically. We accomplish this by forcing usage of `DuckPage`, and by making `DuckPage` suitable for any type of `Page` via its new `.custom` constructor. 

This is a breaking change, but I believe the last one around this topic. I have provided documentation in the README that should help users implement concepts such as dialogs.

Users can migrate by:

- Replacing their `extends Page` with `extends DuckPage`
- If they were overriding `createRoute` in these children, making sure that they use `DuckPage.custom`

## Related Issues

#26 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
