### PR TITLE
feat: add support for fire-and-forget deeplink handling

### DIFF
--- a/flutter/packages/duck_router/README.md
+++ b/flutter/packages/duck_router/README.md
@@ -125,12 +125,14 @@ To enable deeplinking support, add an `onDeepLink` handler to the configuration:
 ```dart
 final router = DuckRouter(
   onDeepLink: (uri, currentLocation) {
-    // do something with the deep link and return a stack of locations
+    // Do something with the deep link. You can choose how to handle the deeplink:
+    // - Immediately return a stack of locations
+    // - Fire-and-forget: save the deeplink in memory and return null here, so you can act upon it later in your own service.
   },
 );
 ```
 
-This gives you the current location and the URI for the deeplink, and asks you to return a stack of locations, with the last entry being the page shown. In cases where it's considered likely for the route to be intercepted (e.g. by a login screen), consider keeping the deeplink location in memory and acting upon it later.
+This gives you the current location and the URI for the deeplink, and asks you to return an optional stack of locations, with the last entry being the page shown. In cases where it's considered likely for the route to be intercepted (e.g. by a login screen), consider keeping the deeplink location in memory and acting upon it later, and returning `null` instead.
 
 ## Custom transitions and custom pages
 

--- a/flutter/packages/duck_router/lib/src/configuration.dart
+++ b/flutter/packages/duck_router/lib/src/configuration.dart
@@ -5,7 +5,7 @@ import 'package:duck_router/src/interceptor.dart';
 import 'package:duck_router/src/location.dart';
 
 /// Handler for when the app gets a deeplink.
-typedef DuckRouterDeepLinkHandler = List<Location> Function(
+typedef DuckRouterDeepLinkHandler = List<Location>? Function(
   Uri uri,
   Location currentLocation,
 );

--- a/flutter/packages/duck_router/lib/src/configuration.dart
+++ b/flutter/packages/duck_router/lib/src/configuration.dart
@@ -5,9 +5,9 @@ import 'package:duck_router/src/interceptor.dart';
 import 'package:duck_router/src/location.dart';
 
 /// Handler for when the app gets a deeplink.
-/// 
+///
 /// When a list of locations is returned, the router will update the current location stack with the new stack.
-/// If `null` is returned, the router will either not update the stack (in case of a deeplink while the app is running) 
+/// If `null` is returned, the router will either not update the stack (in case of a deeplink while the app is running)
 /// or navigate to the initial location (in case of a deeplink while the app is not running).
 typedef DuckRouterDeepLinkHandler = List<Location>? Function(
   Uri uri,

--- a/flutter/packages/duck_router/lib/src/configuration.dart
+++ b/flutter/packages/duck_router/lib/src/configuration.dart
@@ -5,6 +5,10 @@ import 'package:duck_router/src/interceptor.dart';
 import 'package:duck_router/src/location.dart';
 
 /// Handler for when the app gets a deeplink.
+/// 
+/// When a list of locations is returned, the router will update the current location stack with the new stack.
+/// If `null` is returned, the router will either not update the stack (in case of a deeplink while the app is running) 
+/// or navigate to the initial location (in case of a deeplink while the app is not running).
 typedef DuckRouterDeepLinkHandler = List<Location>? Function(
   Uri uri,
   Location currentLocation,

--- a/flutter/packages/duck_router/lib/src/duck_router.dart
+++ b/flutter/packages/duck_router/lib/src/duck_router.dart
@@ -192,10 +192,13 @@ class DuckRouter implements RouterConfig<LocationStack> {
     }
 
     if (configuration.onDeepLink != null) {
-      return LocationStack(
-        locations: configuration.onDeepLink!(
-            platformInitialLocation, userSpecifiedInitialLocation),
+      final locationStack = configuration.onDeepLink!(
+        platformInitialLocation,
+        userSpecifiedInitialLocation,
       );
+      if (locationStack != null) {
+        return LocationStack(locations: locationStack);
+      }
     }
 
     return LocationStack(

--- a/flutter/packages/duck_router/lib/src/provider.dart
+++ b/flutter/packages/duck_router/lib/src/provider.dart
@@ -79,6 +79,10 @@ class DuckInformationProvider extends RouteInformationProvider
         currentState.location,
       );
 
+      if (stackToGoTo == null || stackToGoTo.isEmpty) {
+        return;
+      }
+
       final toLocation = stackToGoTo.last;
 
       /// Note: you might observe that directly calling `navigate` here means

--- a/flutter/packages/duck_router/lib/src/provider.dart
+++ b/flutter/packages/duck_router/lib/src/provider.dart
@@ -80,6 +80,7 @@ class DuckInformationProvider extends RouteInformationProvider
       );
 
       if (stackToGoTo == null || stackToGoTo.isEmpty) {
+        // If the stack is empty, the user does not want to navigate based on the deeplink.
         return;
       }
 

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -868,6 +868,27 @@ void main() {
       expect(find.byType(Page1Screen), findsNothing);
     });
 
+    testWidgets('ignores deep links if location stack returned (supports the fire-and-forget scenario)', (tester) async {
+      final binding = _retrieveTestBinding(tester);
+      binding.platformDispatcher.defaultRouteNameTestValue = '/page1';
+
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+        onDeepLink: (_, __) => null,
+      );
+
+      final router = await createRouter(
+        config,
+        tester,
+      );
+      final locations = router.routerDelegate.currentConfiguration;
+      await tester.pumpAndSettle();
+
+      expect(locations.uri.path, '/home');
+      expect(find.byType(HomeScreen), findsOneWidget);
+      expect(find.byType(Page1Screen), findsNothing);
+    });
+
     testWidgets('sends empty deep link to initial location', (tester) async {
       final binding = _retrieveTestBinding(tester);
       binding.platformDispatcher.defaultRouteNameTestValue = '';
@@ -947,6 +968,44 @@ void main() {
       final locations2 = router.routerDelegate.currentConfiguration;
 
       expect(locations2.uri.path, '/page1');
+    });
+
+    testWidgets('handles deep link while router is active but returns null as location stack', (tester) async {
+      final binding = _retrieveTestBinding(tester);
+      binding.platformDispatcher.defaultRouteNameTestValue = '';
+
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+        onDeepLink: (deeplink, initialLocation) {
+          return null;
+        },
+      );
+
+      final router = await createRouter(
+        config,
+        tester,
+      );
+      final locations = router.routerDelegate.currentConfiguration;
+      await tester.pumpAndSettle();
+
+      expect(locations.uri.path, '/home');
+
+      const Map<String, dynamic> testRouteInformation = <String, dynamic>{
+        'location': '/page1',
+        'state': 'state',
+        'restorationData': <dynamic, dynamic>{'test': 'config'},
+      };
+      final ByteData message = const JSONMethodCodec().encodeMethodCall(
+        const MethodCall('pushRouteInformation', testRouteInformation),
+      );
+
+      await tester.binding.defaultBinaryMessenger
+          .handlePlatformMessage('flutter/navigation', message, (_) {});
+
+      await tester.pumpAndSettle();
+      final locations2 = router.routerDelegate.currentConfiguration;
+
+      expect(locations2.uri.path, '/home');
     });
 
     // We intentionally do not support this feature, see

--- a/flutter/packages/duck_router/test/src/duck_router_test.dart
+++ b/flutter/packages/duck_router/test/src/duck_router_test.dart
@@ -868,7 +868,9 @@ void main() {
       expect(find.byType(Page1Screen), findsNothing);
     });
 
-    testWidgets('ignores deep links if location stack returned (supports the fire-and-forget scenario)', (tester) async {
+    testWidgets(
+        'ignores deep links if location stack returned (supports the fire-and-forget scenario)',
+        (tester) async {
       final binding = _retrieveTestBinding(tester);
       binding.platformDispatcher.defaultRouteNameTestValue = '/page1';
 
@@ -970,7 +972,9 @@ void main() {
       expect(locations2.uri.path, '/page1');
     });
 
-    testWidgets('handles deep link while router is active but returns null as location stack', (tester) async {
+    testWidgets(
+        'handles deep link while router is active but returns null as location stack',
+        (tester) async {
       final binding = _retrieveTestBinding(tester);
       binding.platformDispatcher.defaultRouteNameTestValue = '';
 


### PR DESCRIPTION
## Description

While implementing deeplinks with this package, we found that when a deeplink is received, we need to immediately return a Location stack. However, we would instead like to either:
- go through the default app startup, and only after handle the deeplink request
- when the app is active, just call a DeeplinkService, and let that service handle the necessary navigation (if any).

This should already be supported, as per the documentation in the readme: 
> consider keeping the deeplink location in memory and acting upon it later.

Since it is required to return a Location stack, our current workaround is to either return the userSpecifiedInitialLocation, or fetch and return the currentConfiguration.locationStack. It is only due to the Router implementation that this in fact does not trigger a navigation (since the Page stack remains the same). However this feels dirty and prone to error in the future.

Making the response of the deeplink callback optional, allows us in a more developer-friendly way handle our scenario.

## Related Issues

/

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
