### PR TITLE
fix: exit not clearing awaiting futures

### DIFF
--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -106,6 +106,17 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       }
     }
 
+    if (currentLocation is StatefulLocation && root) {
+      // When popping a stateful location, we can consider the nested stack to be cleared from the stack.
+      // So we will follow the same cleanup logic as if navigating to a new page, with the clearStack flag set to true.
+      for (final l in currentLocation
+          .state.currentRouterDelegate.currentConfiguration.locations) {
+        _configuration.clearLocation(l);
+      }
+      currentLocation.state.currentRouterDelegate.currentConfiguration.locations
+          .clear();
+    }
+
     NavigatorState? state;
     if (navigatorKey.currentState?.canPop() ?? false) {
       state = navigatorKey.currentState;


### PR DESCRIPTION
## Description

When using te `exit` method to close a nested flow, the stack of the nested flow is removed. However, we are not properly closing all the pending completers for that inner navigation. It's basically the same issue as in #47 and #64 , but then for the `exit` method.

The flow I had that exposed this bug:
- Screen A opens nested screen B.
- Screen B opens and waits for a result from screen C
- Users executes `exit` on screen C -> back on screen A
- User reopens screen B and screen C, and now pops back to B
- Screen B should reload its data, but the bloc's stream (which was tied to the lifecycle of screen B) is already closed!

## Related Issues

#47 
#64 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
