### PR TITLE
feat: add pop until with result method

### DIFF
--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -131,17 +131,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     state?.pop(result);
   }
 
-  void popUntil(LocationPredicate predicate) {
-    _popUntilInternal(predicate);
-  }
-
-  void popUntilWithResult<T extends Object?>(
-      LocationPredicate predicate, T? result) {
-    _popUntilInternal(predicate, result);
-  }
-
-  void _popUntilInternal<T extends Object?>(LocationPredicate predicate,
-      [T? result]) {
+  void popUntil<T extends Object?>(LocationPredicate predicate, [T? result]) {
     final currentLocation = currentConfiguration.locations.last;
 
     if (currentLocation is StatefulLocation) {
@@ -150,9 +140,7 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       if (currentLocation.state.currentRouterDelegate.currentConfiguration
               .locations.length >
           1) {
-        final found = result != null
-            ? currentLocation.state.popUntilWithResult(predicate, result)
-            : currentLocation.state.popUntil(predicate);
+        final found = currentLocation.state.popUntil(predicate, result);
         if (found) {
           return;
         }

--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -132,6 +132,16 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
   }
 
   void popUntil(LocationPredicate predicate) {
+    _popUntilInternal(predicate);
+  }
+
+  void popUntilWithResult<T extends Object?>(
+      LocationPredicate predicate, T? result) {
+    _popUntilInternal(predicate, result);
+  }
+
+  void _popUntilInternal<T extends Object?>(LocationPredicate predicate,
+      [T? result]) {
     final currentLocation = currentConfiguration.locations.last;
 
     if (currentLocation is StatefulLocation) {
@@ -140,8 +150,10 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       if (currentLocation.state.currentRouterDelegate.currentConfiguration
               .locations.length >
           1) {
-        final result = currentLocation.state.popUntil(predicate);
-        if (result) {
+        final found = result != null
+            ? currentLocation.state.popUntilWithResult(predicate, result)
+            : currentLocation.state.popUntil(predicate);
+        if (found) {
           return;
         }
       }
@@ -157,9 +169,9 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     if (navigatorKey.currentState?.canPop() ?? false) {
       state = navigatorKey.currentState;
     }
-    state?.popUntil((route) {
+    state?.popUntilWithResult((route) {
       return route.settings.name == destination.path;
-    });
+    }, result);
   }
 
   /// Reset the router to the root

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -227,6 +227,13 @@ class DuckRouter implements RouterConfig<LocationStack> {
     routerDelegate.popUntil(predicate);
   }
 
+  /// Pop until the given predicate is satisfied, passing [result] back
+  /// to the destination location, completing any awaited [navigate] call.
+  void popUntilWithResult<T extends Object?>(
+      LocationPredicate predicate, T? result) {
+    routerDelegate.popUntilWithResult(predicate, result);
+  }
+
   /// Reset the router to the root location.
   void root() {
     routerDelegate.root();

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -223,15 +223,11 @@ class DuckRouter implements RouterConfig<LocationStack> {
   }
 
   /// Pop until the given predicate is satisfied.
-  void popUntil(LocationPredicate predicate) {
-    routerDelegate.popUntil(predicate);
-  }
-
-  /// Pop until the given predicate is satisfied, passing [result] back
-  /// to the destination location, completing any awaited [navigate] call.
-  void popUntilWithResult<T extends Object?>(
-      LocationPredicate predicate, T? result) {
-    routerDelegate.popUntilWithResult(predicate, result);
+  ///
+  /// If [result] is provided, it will be passed back to the destination
+  /// location, completing any awaited [navigate] call.
+  void popUntil<T extends Object?>(LocationPredicate predicate, [T? result]) {
+    routerDelegate.popUntil(predicate, result);
   }
 
   /// Reset the router to the root location.

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -173,6 +173,16 @@ class DuckShellState extends State<DuckShell> {
   }
 
   bool popUntil(LocationPredicate predicate) {
+    return _popUntilInternal(predicate);
+  }
+
+  bool popUntilWithResult<T extends Object?>(
+      LocationPredicate predicate, T? result) {
+    return _popUntilInternal(predicate, result);
+  }
+
+  bool _popUntilInternal<T extends Object?>(LocationPredicate predicate,
+      [T? result]) {
     final navigatorKey = _navigatorKeys[_currentIndex];
     if (navigatorKey.currentState == null) {
       return false;
@@ -185,9 +195,9 @@ class DuckShellState extends State<DuckShell> {
       return false;
     }
 
-    navigatorKey.currentState?.popUntil((route) {
+    navigatorKey.currentState?.popUntilWithResult((route) {
       return route.settings.name == destination.path;
-    });
+    }, result);
 
     return true;
   }

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -172,17 +172,7 @@ class DuckShellState extends State<DuckShell> {
     navigatorKey.currentState?.pop(result);
   }
 
-  bool popUntil(LocationPredicate predicate) {
-    return _popUntilInternal(predicate);
-  }
-
-  bool popUntilWithResult<T extends Object?>(
-      LocationPredicate predicate, T? result) {
-    return _popUntilInternal(predicate, result);
-  }
-
-  bool _popUntilInternal<T extends Object?>(LocationPredicate predicate,
-      [T? result]) {
+  bool popUntil<T extends Object?>(LocationPredicate predicate, [T? result]) {
     final navigatorKey = _navigatorKeys[_currentIndex];
     if (navigatorKey.currentState == null) {
       return false;

--- a/duck_router/pubspec.yaml
+++ b/duck_router/pubspec.yaml
@@ -12,7 +12,7 @@ platforms:
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.41.0"
 
 dependencies:
   collection: ^1.18.0

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -236,7 +236,7 @@ void main() {
     /// Screen A --- navigates to and waits for result of ---> Screen B
     /// Screen B --- navigates to ---> Screen C
     /// Screen C --- popUntil Screen A with result ---> Screen A
-    testWidgets('popUntilWithResult returns result to awaiting location',
+    testWidgets('popUntil with result returns result to awaiting location',
         (tester) async {
       final config = DuckRouterConfiguration(
         initialLocation: HomeLocation(),
@@ -276,7 +276,7 @@ void main() {
       expect(locations2.locations.length, 3);
 
       // Screen C pops until Screen A with result
-      router.popUntilWithResult((location) => location is HomeLocation, 42);
+      router.popUntil((location) => location is HomeLocation, 42);
       await tester.pumpAndSettle();
 
       final locations3 = router.routerDelegate.currentConfiguration;


### PR DESCRIPTION
## Description

Flutter 3.41 introduces a new method, popUntilWithResult, which allows returning a result when popping multiple pages at once, with only the "until" page receiving the result.

Added a new method on duckRouter to enable this functionality.

## Related Issues

/

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is _not_ a breaking change.
