### PR TITLE
fix: sync route information provider value after pop

### DIFF
--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -62,6 +62,9 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       newLocation.state.takePriority();
     }
 
+    // Notify so that [DuckRouter] can re-sync the [DuckInformationProvider]'s
+    // cached value to the new stack. Otherwise the provider keeps pointing at
+    // the popped location, and [Router] will re-push it on rebuild/hot reload.
     notifyListeners();
   }
 

--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -61,6 +61,8 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     if (newLocation is StatefulLocation) {
       newLocation.state.takePriority();
     }
+
+    notifyListeners();
   }
 
   @override

--- a/duck_router/lib/src/delegate.dart
+++ b/duck_router/lib/src/delegate.dart
@@ -22,6 +22,12 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
   final DuckRouterConfiguration _configuration;
   final DuckRouterShellBuilder _shellBuilder;
 
+  /// Set while [popRoute] is delegating to [NavigatorState.maybePop]. The
+  /// [Router] will rebuild and re-report on its own when [popRoute]'s future
+  /// resolves (see [_RouterState._handleRoutePopped]), so [_onPopPage] skips
+  /// the otherwise-required [notifyListeners] on that path.
+  bool _isHandlingBackButton = false;
+
   @override
   Widget build(BuildContext context) {
     return _shellBuilder(
@@ -62,10 +68,14 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
       newLocation.state.takePriority();
     }
 
-    // Notify so that [DuckRouter] can re-sync the [DuckInformationProvider]'s
-    // cached value to the new stack. Otherwise the provider keeps pointing at
-    // the popped location, and [Router] will re-push it on rebuild/hot reload.
-    notifyListeners();
+    // Notify so [Router] rebuilds and reports the new configuration back to
+    // [DuckInformationProvider] via [routerReportsNewRouteInformation].
+    // Without this, the provider's cached value keeps pointing at the popped
+    // location and [Router] re-pushes it on rebuild/hot reload.
+    //
+    // Skipped on the back-button path: [Router] already rebuilds + reports
+    // after [popRoute] resolves, so notifying here would just double up.
+    if (!_isHandlingBackButton) notifyListeners();
   }
 
   @override
@@ -95,7 +105,12 @@ class DuckRouterDelegate extends RouterDelegate<LocationStack>
     }
 
     if (state != null) {
-      return state.maybePop();
+      _isHandlingBackButton = true;
+      try {
+        return await state.maybePop();
+      } finally {
+        _isHandlingBackButton = false;
+      }
     }
 
     return false;

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -75,14 +75,36 @@ class DuckRouter implements RouterConfig<LocationStack> {
       stack: _initialLocation(configuration.initialLocation),
       configuration: configuration,
     );
-    routerDelegate.addListener(() {
-      final providerLocation =
-          (routeInformationProvider.value.state as LocationState).location;
-      final delegateLocations = routerDelegate.currentConfiguration.locations;
-      if (!delegateLocations.contains(providerLocation)) {
-        routeInformationProvider.syncValue(routerDelegate.currentConfiguration);
-      }
-    });
+    routerDelegate.addListener(_syncProviderIfStale);
+  }
+
+  /// Re-syncs [routeInformationProvider] when the delegate's stack no longer
+  /// contains the location the provider currently points to (e.g. after a pop
+  /// triggered by the system back button). Without this, [Router] can re-push
+  /// the popped route on rebuild/hot reload by re-reading the stale value.
+  void _syncProviderIfStale() {
+    final providerLocation =
+        (routeInformationProvider.value.state as LocationState).location;
+    final delegateLocations = routerDelegate.currentConfiguration.locations;
+    if (!delegateLocations.contains(providerLocation)) {
+      routeInformationProvider.syncValue(routerDelegate.currentConfiguration);
+    }
+  }
+
+  /// Disposes the router and its associated resources.
+  ///
+  /// After calling this, the router must not be used anymore.
+  ///
+  /// Note: this is not wired into any framework-driven teardown. Flutter's
+  /// [Router] does not dispose its [RouterConfig], and [InheritedDuckRouter]
+  /// is built inside [routerDelegate], so it cannot own this instance's
+  /// lifecycle. Most apps hold a single [DuckRouter] for the app's lifetime
+  /// and never need to call this; callers who replace the router at runtime
+  /// are responsible for invoking [dispose] on the previous instance.
+  void dispose() {
+    routerDelegate.removeListener(_syncProviderIfStale);
+    routerDelegate.dispose();
+    routeInformationProvider.dispose();
   }
 
   /// Find the current DuckRouter in the widget tree.

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -5,6 +5,7 @@ import 'package:duck_router/src/interceptor.dart';
 import 'package:duck_router/src/location.dart';
 import 'package:duck_router/src/parser.dart';
 import 'package:duck_router/src/provider.dart';
+import 'package:duck_router/src/state.dart';
 import 'package:flutter/material.dart';
 
 /// A builder for a shell around the [DuckRouter].
@@ -74,6 +75,14 @@ class DuckRouter implements RouterConfig<LocationStack> {
       stack: _initialLocation(configuration.initialLocation),
       configuration: configuration,
     );
+    routerDelegate.addListener(() {
+      final providerLocation =
+          (routeInformationProvider.value.state as LocationState).location;
+      final delegateLocations = routerDelegate.currentConfiguration.locations;
+      if (!delegateLocations.contains(providerLocation)) {
+        routeInformationProvider.syncValue(routerDelegate.currentConfiguration);
+      }
+    });
   }
 
   /// Find the current DuckRouter in the widget tree.

--- a/duck_router/lib/src/duck_router.dart
+++ b/duck_router/lib/src/duck_router.dart
@@ -5,7 +5,6 @@ import 'package:duck_router/src/interceptor.dart';
 import 'package:duck_router/src/location.dart';
 import 'package:duck_router/src/parser.dart';
 import 'package:duck_router/src/provider.dart';
-import 'package:duck_router/src/state.dart';
 import 'package:flutter/material.dart';
 
 /// A builder for a shell around the [DuckRouter].
@@ -75,20 +74,6 @@ class DuckRouter implements RouterConfig<LocationStack> {
       stack: _initialLocation(configuration.initialLocation),
       configuration: configuration,
     );
-    routerDelegate.addListener(_syncProviderIfStale);
-  }
-
-  /// Re-syncs [routeInformationProvider] when the delegate's stack no longer
-  /// contains the location the provider currently points to (e.g. after a pop
-  /// triggered by the system back button). Without this, [Router] can re-push
-  /// the popped route on rebuild/hot reload by re-reading the stale value.
-  void _syncProviderIfStale() {
-    final providerLocation =
-        (routeInformationProvider.value.state as LocationState).location;
-    final delegateLocations = routerDelegate.currentConfiguration.locations;
-    if (!delegateLocations.contains(providerLocation)) {
-      routeInformationProvider.syncValue(routerDelegate.currentConfiguration);
-    }
   }
 
   /// Disposes the router and its associated resources.
@@ -102,7 +87,6 @@ class DuckRouter implements RouterConfig<LocationStack> {
   /// and never need to call this; callers who replace the router at runtime
   /// are responsible for invoking [dispose] on the previous instance.
   void dispose() {
-    routerDelegate.removeListener(_syncProviderIfStale);
     routerDelegate.dispose();
     routeInformationProvider.dispose();
   }

--- a/duck_router/lib/src/provider.dart
+++ b/duck_router/lib/src/provider.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:duck_router/src/configuration.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:duck_router/src/location.dart';
 import 'state.dart';
 
@@ -17,6 +19,7 @@ class DuckInformationProvider extends RouteInformationProvider
     required LocationStack stack,
     required DuckRouterConfiguration configuration,
   })  : _configuration = configuration,
+        _codec = LocationStackCodec(configuration: configuration),
         _value = RouteInformation(
           uri: stack.uri,
           state: LocationState(
@@ -34,6 +37,7 @@ class DuckInformationProvider extends RouteInformationProvider
   RouteInformation _value;
 
   final DuckRouterConfiguration _configuration;
+  final LocationStackCodec _codec;
 
   static WidgetsBinding get _binding => WidgetsBinding.instance;
 
@@ -69,35 +73,50 @@ class DuckInformationProvider extends RouteInformationProvider
     return completer.future;
   }
 
-  /// Synchronises [_value] with the current [LocationStack].
+  /// Syncs [_value] with what the [Router] reports after rebuilding from the
+  /// delegate's [RouterDelegate.currentConfiguration]. Without this, [_value]
+  /// would keep pointing at a popped location, and the [Router] would re-push
+  /// it on rebuild or hot reload by re-reading [_value].
   ///
-  /// Called after pops/resets to prevent stale [_value] from causing
-  /// [Router] to re-push a popped route on rebuild or hot reload.
-  ///
-  /// No-op (and no notification) when [_value] already matches [stack], to
-  /// avoid spurious parse/restore round-trips through the [Router].
-  void syncValue(LocationStack stack) {
-    final currentState = _value.state;
-    if (currentState is LocationState) {
-      final currentStack = LocationStack(
-        locations: [
-          ...currentState.baseLocationStack.locations,
-          currentState.location,
-        ],
-      );
-      if (currentStack == stack) return;
+  /// Also forwards the new route information to the engine so the platform
+  /// (browser URL bar, OS back stack) reflects the current stack — mirroring
+  /// [PlatformRouteInformationProvider.routerReportsNewRouteInformation].
+  @override
+  void routerReportsNewRouteInformation(
+    RouteInformation routeInformation, {
+    RouteInformationReportingType type = RouteInformationReportingType.none,
+  }) {
+    if (_value.uri == routeInformation.uri &&
+        const DeepCollectionEquality()
+            .equals(_value.state, routeInformation.state)) {
+      return;
     }
+    _value = routeInformation;
 
-    _value = RouteInformation(
-      uri: stack.uri,
-      state: LocationState(
-        location: stack.locations.last,
-        baseLocationStack: stack.copyWith(
-          locations: stack.locations.sublist(0, stack.locations.length - 1),
-        ),
-      ),
+    SystemNavigator.selectMultiEntryHistory();
+    SystemNavigator.routeInformationUpdated(
+      uri: routeInformation.uri,
+      replace: type != RouteInformationReportingType.navigate,
     );
-    notifyListeners();
+  }
+
+  /// Returns the current [Location] the provider points to, regardless of
+  /// whether [value]'s state is a freshly built [LocationState] (after a
+  /// [navigate]) or the encoded [Map] form (after a [Router] rebuild reported
+  /// via [routerReportsNewRouteInformation]).
+  Location? get currentLocation {
+    final state = _value.state;
+    if (state is LocationState) {
+      return state.location;
+    }
+    if (state is Map<Object?, Object?>) {
+      try {
+        return _codec.decode(state).locations.lastOrNull;
+      } catch (_) {
+        return null;
+      }
+    }
+    return null;
   }
 
   void _platformReportsNewRouteInformation(RouteInformation routeInformation) {
@@ -106,10 +125,11 @@ class DuckInformationProvider extends RouteInformationProvider
     }
 
     if (_configuration.onDeepLink != null) {
-      final currentState = _value.state as LocationState;
+      final currentLocation = this.currentLocation;
+      if (currentLocation == null) return;
       final stackToGoTo = _configuration.onDeepLink!(
         routeInformation.uri,
-        currentState.location,
+        currentLocation,
       );
 
       if (stackToGoTo == null || stackToGoTo.isEmpty) {

--- a/duck_router/lib/src/provider.dart
+++ b/duck_router/lib/src/provider.dart
@@ -5,7 +5,6 @@ import 'package:duck_router/src/configuration.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:duck_router/src/location.dart';
 import 'state.dart';
 
@@ -77,10 +76,6 @@ class DuckInformationProvider extends RouteInformationProvider
   /// delegate's [RouterDelegate.currentConfiguration]. Without this, [_value]
   /// would keep pointing at a popped location, and the [Router] would re-push
   /// it on rebuild or hot reload by re-reading [_value].
-  ///
-  /// Also forwards the new route information to the engine so the platform
-  /// (browser URL bar, OS back stack) reflects the current stack — mirroring
-  /// [PlatformRouteInformationProvider.routerReportsNewRouteInformation].
   @override
   void routerReportsNewRouteInformation(
     RouteInformation routeInformation, {
@@ -92,12 +87,6 @@ class DuckInformationProvider extends RouteInformationProvider
       return;
     }
     _value = routeInformation;
-
-    SystemNavigator.selectMultiEntryHistory();
-    SystemNavigator.routeInformationUpdated(
-      uri: routeInformation.uri,
-      replace: type != RouteInformationReportingType.navigate,
-    );
   }
 
   /// Returns the current [Location] the provider points to, regardless of
@@ -110,11 +99,7 @@ class DuckInformationProvider extends RouteInformationProvider
       return state.location;
     }
     if (state is Map<Object?, Object?>) {
-      try {
-        return _codec.decode(state).locations.lastOrNull;
-      } catch (_) {
-        return null;
-      }
+      return _codec.decode(state).locations.lastOrNull;
     }
     return null;
   }

--- a/duck_router/lib/src/provider.dart
+++ b/duck_router/lib/src/provider.dart
@@ -74,7 +74,20 @@ class DuckInformationProvider extends RouteInformationProvider
   /// Called after pops/resets to prevent stale [_value] from causing
   /// [Router] to re-push a popped route on rebuild or hot reload.
   ///
+  /// No-op (and no notification) when [_value] already matches [stack], to
+  /// avoid spurious parse/restore round-trips through the [Router].
   void syncValue(LocationStack stack) {
+    final currentState = _value.state;
+    if (currentState is LocationState) {
+      final currentStack = LocationStack(
+        locations: [
+          ...currentState.baseLocationStack.locations,
+          currentState.location,
+        ],
+      );
+      if (currentStack == stack) return;
+    }
+
     _value = RouteInformation(
       uri: stack.uri,
       state: LocationState(

--- a/duck_router/lib/src/provider.dart
+++ b/duck_router/lib/src/provider.dart
@@ -69,6 +69,24 @@ class DuckInformationProvider extends RouteInformationProvider
     return completer.future;
   }
 
+  /// Synchronises [_value] with the current [LocationStack].
+  ///
+  /// Called after pops/resets to prevent stale [_value] from causing
+  /// [Router] to re-push a popped route on rebuild or hot reload.
+  ///
+  void syncValue(LocationStack stack) {
+    _value = RouteInformation(
+      uri: stack.uri,
+      state: LocationState(
+        location: stack.locations.last,
+        baseLocationStack: stack.copyWith(
+          locations: stack.locations.sublist(0, stack.locations.length - 1),
+        ),
+      ),
+    );
+    notifyListeners();
+  }
+
   void _platformReportsNewRouteInformation(RouteInformation routeInformation) {
     if (_value == routeInformation) {
       return;

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -4,7 +4,6 @@ import 'package:collection/collection.dart';
 import 'package:duck_router/duck_router.dart';
 import 'package:duck_router/src/parser.dart';
 import 'package:duck_router/src/provider.dart';
-import 'package:duck_router/src/state.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -68,7 +67,6 @@ class DuckShellState extends State<DuckShell> {
   final List<_NestedRouterDelegate> _routerDelegates = [];
   final List<DuckInformationParser> _informationParsers = [];
   final List<DuckInformationProvider> _informationProviders = [];
-  final List<VoidCallback> _syncListeners = [];
   final List<ChildBackButtonDispatcher> _backButtonDispatchers = [];
 
   @override
@@ -96,21 +94,6 @@ class DuckShellState extends State<DuckShell> {
         configuration: widget.configuration,
       );
       _informationProviders.add(provider);
-      final delegate = _routerDelegates[index];
-      // Re-sync the provider's cached value whenever the delegate's stack no
-      // longer contains the location the provider points to. See
-      // [DuckRouter._syncProviderIfStale] for details.
-      void syncIfStale() {
-        final providerLocation =
-            (provider.value.state as LocationState).location;
-        final delegateLocations = delegate.currentConfiguration.locations;
-        if (!delegateLocations.contains(providerLocation)) {
-          provider.syncValue(delegate.currentConfiguration);
-        }
-      }
-
-      _syncListeners.add(syncIfStale);
-      delegate.addListener(syncIfStale);
     }
 
     super.initState();
@@ -146,7 +129,6 @@ class DuckShellState extends State<DuckShell> {
   @override
   void dispose() {
     for (var i = 0; i < _routerDelegates.length; i++) {
-      _routerDelegates[i].removeListener(_syncListeners[i]);
       _routerDelegates[i].dispose();
       _informationProviders[i].dispose();
     }
@@ -252,6 +234,9 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
   final GlobalKey<NavigatorState> _navigatorKey;
   final DuckRouterConfiguration _routerConfiguration;
 
+  /// See [DuckRouterDelegate._isHandlingBackButton].
+  bool _isHandlingBackButton = false;
+
   @override
   Widget build(BuildContext context) {
     return DuckNavigator(
@@ -280,11 +265,22 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
     currentConfiguration.locations
         .removeWhere((l) => l.path == currentLocation.path);
 
-    // Notify so [DuckShellState]'s listener can re-sync the nested
-    // [DuckInformationProvider] to the new stack. Otherwise the provider keeps
-    // pointing at the popped location, and [Router] will re-push it on
-    // rebuild/hot reload.
-    notifyListeners();
+    // Notify so the nested [Router] rebuilds and reports the new
+    // configuration back to its [DuckInformationProvider] via
+    // [routerReportsNewRouteInformation]. See [DuckRouterDelegate._onPopPage].
+    if (!_isHandlingBackButton) notifyListeners();
+  }
+
+  @override
+  Future<bool> popRoute() async {
+    final state = navigatorKey.currentState;
+    if (state == null) return false;
+    _isHandlingBackButton = true;
+    try {
+      return await state.maybePop();
+    } finally {
+      _isHandlingBackButton = false;
+    }
   }
 
   @override

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -68,6 +68,7 @@ class DuckShellState extends State<DuckShell> {
   final List<_NestedRouterDelegate> _routerDelegates = [];
   final List<DuckInformationParser> _informationParsers = [];
   final List<DuckInformationProvider> _informationProviders = [];
+  final List<VoidCallback> _syncListeners = [];
   final List<ChildBackButtonDispatcher> _backButtonDispatchers = [];
 
   @override
@@ -95,15 +96,21 @@ class DuckShellState extends State<DuckShell> {
         configuration: widget.configuration,
       );
       _informationProviders.add(provider);
-      _routerDelegates[index].addListener(() {
+      final delegate = _routerDelegates[index];
+      // Re-sync the provider's cached value whenever the delegate's stack no
+      // longer contains the location the provider points to. See
+      // [DuckRouter._syncProviderIfStale] for details.
+      void syncIfStale() {
         final providerLocation =
             (provider.value.state as LocationState).location;
-        final delegateLocations =
-            _routerDelegates[index].currentConfiguration.locations;
+        final delegateLocations = delegate.currentConfiguration.locations;
         if (!delegateLocations.contains(providerLocation)) {
-          provider.syncValue(_routerDelegates[index].currentConfiguration);
+          provider.syncValue(delegate.currentConfiguration);
         }
-      });
+      }
+
+      _syncListeners.add(syncIfStale);
+      delegate.addListener(syncIfStale);
     }
 
     super.initState();
@@ -138,6 +145,11 @@ class DuckShellState extends State<DuckShell> {
 
   @override
   void dispose() {
+    for (var i = 0; i < _routerDelegates.length; i++) {
+      _routerDelegates[i].removeListener(_syncListeners[i]);
+      _routerDelegates[i].dispose();
+      _informationProviders[i].dispose();
+    }
     super.dispose();
   }
 
@@ -268,6 +280,10 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
     currentConfiguration.locations
         .removeWhere((l) => l.path == currentLocation.path);
 
+    // Notify so [DuckShellState]'s listener can re-sync the nested
+    // [DuckInformationProvider] to the new stack. Otherwise the provider keeps
+    // pointing at the popped location, and [Router] will re-push it on
+    // rebuild/hot reload.
     notifyListeners();
   }
 

--- a/duck_router/lib/src/shell.dart
+++ b/duck_router/lib/src/shell.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:duck_router/duck_router.dart';
 import 'package:duck_router/src/parser.dart';
 import 'package:duck_router/src/provider.dart';
+import 'package:duck_router/src/state.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -89,10 +90,20 @@ class DuckShellState extends State<DuckShell> {
 
       _informationParsers
           .add(DuckInformationParser(configuration: widget.configuration));
-      _informationProviders.add(DuckInformationProvider(
+      final provider = DuckInformationProvider(
         stack: stack,
         configuration: widget.configuration,
-      ));
+      );
+      _informationProviders.add(provider);
+      _routerDelegates[index].addListener(() {
+        final providerLocation =
+            (provider.value.state as LocationState).location;
+        final delegateLocations =
+            _routerDelegates[index].currentConfiguration.locations;
+        if (!delegateLocations.contains(providerLocation)) {
+          provider.syncValue(_routerDelegates[index].currentConfiguration);
+        }
+      });
     }
 
     super.initState();
@@ -256,6 +267,8 @@ class _NestedRouterDelegate extends RouterDelegate<LocationStack>
 
     currentConfiguration.locations
         .removeWhere((l) => l.path == currentLocation.path);
+
+    notifyListeners();
   }
 
   @override

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -6,7 +6,6 @@ import 'package:duck_router/src/configuration.dart';
 import 'package:duck_router/src/duck_router.dart';
 import 'package:duck_router/src/exception.dart';
 import 'package:duck_router/src/location.dart';
-import 'package:duck_router/src/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1990,9 +1989,8 @@ void main() {
       expect(locations.uri.path, '/home/page1');
 
       // Verify provider value points to Page1.
-      var providerState =
-          router.routeInformationProvider.value.state as LocationState;
-      expect(providerState.location, isA<Page1Location>());
+      expect(router.routeInformationProvider.currentLocation,
+          isA<Page1Location>());
 
       // Pop Page1.
       router.pop();
@@ -2005,10 +2003,8 @@ void main() {
 
       // BUG: After pop, provider value should reflect the current stack
       // (HomeLocation), but it still points to the popped Page1Location.
-      providerState =
-          router.routeInformationProvider.value.state as LocationState;
       expect(
-        providerState.location,
+        router.routeInformationProvider.currentLocation,
         isA<HomeLocation>(),
         reason: 'Provider value should be updated after pop to reflect '
             'the current stack. A stale value causes hot reload to '
@@ -2033,9 +2029,8 @@ void main() {
       expect(locations.locations.length, 2);
 
       // Verify provider value points to the flow.
-      var providerState =
-          router.routeInformationProvider.value.state as LocationState;
-      expect(providerState.location, isA<TestFlowLocation>());
+      expect(router.routeInformationProvider.currentLocation,
+          isA<TestFlowLocation>());
 
       // Pop via system back button (bypasses DuckRouter.pop).
       await tester.binding.handlePopRoute();
@@ -2046,18 +2041,15 @@ void main() {
       expect(locations.uri.path, '/home');
 
       // After back button pop, provider value should reflect current stack.
-      providerState =
-          router.routeInformationProvider.value.state as LocationState;
       expect(
-        providerState.location,
+        router.routeInformationProvider.currentLocation,
         isA<HomeLocation>(),
         reason: 'Provider value should be updated after back button pop. '
             'A stale value causes hot reload to re-push the popped route.',
       );
     });
 
-    testWidgets('dispose detaches the sync listener and disposes resources',
-        (tester) async {
+    testWidgets('dispose tears down the delegate and provider', (tester) async {
       final config = DuckRouterConfiguration(
         initialLocation: HomeLocation(),
       );
@@ -2066,11 +2058,8 @@ void main() {
 
       router.dispose();
 
-      // After dispose, the delegate and provider are torn down. Calling
-      // dispose() again on an already-disposed ChangeNotifier throws, so we
-      // use that to assert disposal happened. The sync listener is also
-      // detached, so notifying again does not call back into the (now
-      // disposed) provider.
+      // Calling dispose() again on an already-disposed ChangeNotifier throws,
+      // which lets us assert disposal happened on both components.
       expect(() => router.routerDelegate.dispose(), throwsFlutterError);
       expect(
         () => router.routeInformationProvider.dispose(),

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -3,8 +3,10 @@
 import 'dart:async';
 
 import 'package:duck_router/src/configuration.dart';
+import 'package:duck_router/src/duck_router.dart';
 import 'package:duck_router/src/exception.dart';
 import 'package:duck_router/src/location.dart';
+import 'package:duck_router/src/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1843,6 +1845,215 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.byType(Page1Screen), findsOneWidget);
       });
+    });
+
+    testWidgets('nested provider value reflects current stack after pop',
+        (tester) async {
+      final streamController = StreamController<int>.broadcast();
+      addTearDown(() => streamController.close());
+
+      final config = DuckRouterConfiguration(
+        initialLocation: RootLocation(),
+      );
+
+      final router = DuckRouter.withConfig(configuration: config);
+      final appKey = GlobalKey();
+
+      await tester.pumpWidget(
+        StreamBuilder(
+          stream: streamController.stream,
+          builder: (context, snapshot) {
+            Widget child = KeyedSubtree(
+              key: appKey,
+              child: MaterialApp.router(routerConfig: router),
+            );
+            if (snapshot.data == 3) {
+              child = Container(child: child);
+            }
+            return child;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Navigate inside the nested (stateful) location.
+      router.navigate(to: Page2Location());
+      await tester.pumpAndSettle();
+
+      final statefulLocation = router.routerDelegate.currentConfiguration
+          .locations.last as StatefulLocation;
+      var innerConfig =
+          statefulLocation.state.currentRouterDelegate.currentConfiguration;
+      expect(innerConfig.uri.path, '/child1/page2');
+
+      // Pop inside the nested stack.
+      router.pop();
+      await tester.pumpAndSettle();
+
+      innerConfig =
+          statefulLocation.state.currentRouterDelegate.currentConfiguration;
+      expect(innerConfig.locations.length, 1);
+      expect(innerConfig.uri.path, '/child1');
+
+      // Trigger a rebuild (simulates hot reload).
+      streamController.add(3);
+      await tester.pumpAndSettle();
+
+      // The popped page should NOT reappear.
+      innerConfig =
+          statefulLocation.state.currentRouterDelegate.currentConfiguration;
+      expect(
+        innerConfig.locations.length,
+        1,
+        reason: 'Nested provider value should be updated after pop. '
+            'A stale value causes hot reload to re-push the popped route.',
+      );
+      expect(innerConfig.uri.path, '/child1');
+    });
+
+    testWidgets(
+        'nested provider value reflects current stack after back button pop',
+        (tester) async {
+      final streamController = StreamController<int>.broadcast();
+      addTearDown(() => streamController.close());
+
+      final config = DuckRouterConfiguration(
+        initialLocation: RootLocation(),
+      );
+
+      final router = DuckRouter.withConfig(configuration: config);
+
+      await tester.pumpWidget(
+        StreamBuilder(
+          stream: streamController.stream,
+          builder: (context, snapshot) {
+            Widget child = MaterialApp.router(routerConfig: router);
+            if (snapshot.data == 3) {
+              child = Container(child: child);
+            }
+            return child;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Navigate inside the nested (stateful) location.
+      router.navigate(to: Page2Location());
+      await tester.pumpAndSettle();
+
+      final statefulLocation = router.routerDelegate.currentConfiguration
+          .locations.last as StatefulLocation;
+      var innerConfig =
+          statefulLocation.state.currentRouterDelegate.currentConfiguration;
+      expect(innerConfig.uri.path, '/child1/page2');
+
+      // Pop inside the nested stack via system back button.
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      innerConfig =
+          statefulLocation.state.currentRouterDelegate.currentConfiguration;
+      expect(innerConfig.locations.length, 1);
+      expect(innerConfig.uri.path, '/child1');
+
+      // Trigger a rebuild (simulates hot reload).
+      streamController.add(3);
+      await tester.pumpAndSettle();
+
+      // The popped page should NOT reappear.
+      innerConfig =
+          statefulLocation.state.currentRouterDelegate.currentConfiguration;
+      expect(
+        innerConfig.locations.length,
+        1,
+        reason: 'Nested provider value should be updated after back button '
+            'pop. A stale value causes hot reload to re-push the popped route.',
+      );
+      expect(innerConfig.uri.path, '/child1');
+    });
+
+    testWidgets('provider value reflects current stack after pop',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      await tester.pumpAndSettle();
+
+      // Navigate to Page1.
+      router.navigate(to: Page1Location());
+      await tester.pumpAndSettle();
+
+      var locations = router.routerDelegate.currentConfiguration;
+      expect(locations.locations.length, 2);
+      expect(locations.uri.path, '/home/page1');
+
+      // Verify provider value points to Page1.
+      var providerState =
+          router.routeInformationProvider.value.state as LocationState;
+      expect(providerState.location, isA<Page1Location>());
+
+      // Pop Page1.
+      router.pop();
+      await tester.pumpAndSettle();
+
+      locations = router.routerDelegate.currentConfiguration;
+      expect(locations.locations.length, 1);
+      expect(locations.uri.path, '/home');
+      expect(find.byType(HomeScreen), findsOneWidget);
+
+      // BUG: After pop, provider value should reflect the current stack
+      // (HomeLocation), but it still points to the popped Page1Location.
+      providerState =
+          router.routeInformationProvider.value.state as LocationState;
+      expect(
+        providerState.location,
+        isA<HomeLocation>(),
+        reason: 'Provider value should be updated after pop to reflect '
+            'the current stack. A stale value causes hot reload to '
+            're-push the popped route.',
+      );
+    });
+
+    testWidgets('provider value reflects current stack after back button pop',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = await createRouter(config, tester);
+      await tester.pumpAndSettle();
+
+      // Navigate to a FlowLocation.
+      router.navigate(to: TestFlowLocation());
+      await tester.pumpAndSettle();
+
+      var locations = router.routerDelegate.currentConfiguration;
+      expect(locations.locations.length, 2);
+
+      // Verify provider value points to the flow.
+      var providerState =
+          router.routeInformationProvider.value.state as LocationState;
+      expect(providerState.location, isA<TestFlowLocation>());
+
+      // Pop via system back button (bypasses DuckRouter.pop).
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      locations = router.routerDelegate.currentConfiguration;
+      expect(locations.locations.length, 1);
+      expect(locations.uri.path, '/home');
+
+      // After back button pop, provider value should reflect current stack.
+      providerState =
+          router.routeInformationProvider.value.state as LocationState;
+      expect(
+        providerState.location,
+        isA<HomeLocation>(),
+        reason: 'Provider value should be updated after back button pop. '
+            'A stale value causes hot reload to re-push the popped route.',
+      );
     });
   });
 

--- a/duck_router/test/src/duck_router_test.dart
+++ b/duck_router/test/src/duck_router_test.dart
@@ -2055,6 +2055,28 @@ void main() {
             'A stale value causes hot reload to re-push the popped route.',
       );
     });
+
+    testWidgets('dispose detaches the sync listener and disposes resources',
+        (tester) async {
+      final config = DuckRouterConfiguration(
+        initialLocation: HomeLocation(),
+      );
+
+      final router = DuckRouter.withConfig(configuration: config);
+
+      router.dispose();
+
+      // After dispose, the delegate and provider are torn down. Calling
+      // dispose() again on an already-disposed ChangeNotifier throws, so we
+      // use that to assert disposal happened. The sync listener is also
+      // detached, so notifying again does not call back into the (now
+      // disposed) provider.
+      expect(() => router.routerDelegate.dispose(), throwsFlutterError);
+      expect(
+        () => router.routeInformationProvider.dispose(),
+        throwsFlutterError,
+      );
+    });
   });
 
   group('Deeplinking', () {


### PR DESCRIPTION
## Description

After popping a route, DuckInformationProvider._value still pointed to the popped location. On hot reload or widget rebuild, Flutter's Router re-read this stale value and re-pushed the popped route.

- Add DuckInformationProvider.syncValue() to update _value from the current LocationStack after a pop
- Both DuckRouterDelegate and _NestedRouterDelegate now hold a direct reference to their DuckInformationProvider and call syncValue after updating currentConfiguration in onPopPage and root()
- The delegate calls notifyListeners() after syncing so Flutter's Router updates its internal route information cache without re-parsing through interceptors
- Initialize routeInformationProvider before routerDelegate in DuckRouter and DuckShellState so the provider reference can be passed to the delegate constructor

The original bug that made me uncover this, was when I toggled accessibility tools from my debug menu: this rebuilds the app, but when a modal flow was opened before, this became active again. When popping that screen, it actually removed a different Location object from the DuckRouterStack, so all hell broke loose. 

## Related Issues

/

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is _not_ a breaking change.
